### PR TITLE
Fix ConfigurationApply endpoint handling

### DIFF
--- a/internal/controller/configurationapply/configurationapply.go
+++ b/internal/controller/configurationapply/configurationapply.go
@@ -326,7 +326,7 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 
 	// Create client config - support insecure mode for maintenance mode machines
 	clientConfig := cr.Spec.ForProvider.ClientConfiguration
-	endpoints := []string{cr.Spec.ForProvider.Node + ":50000"} // Default Talos port
+	endpoint := getConfigurationApplyEndpoint(cr)
 
 	var talosClient *talosclient.Client
 
@@ -334,7 +334,7 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 		// Use insecure gRPC connection for machines in maintenance mode
 		fmt.Printf("Using insecure gRPC connection for maintenance mode machine\n")
 		talosClient, err = talosclient.New(ctx,
-			talosclient.WithEndpoints(endpoints...),
+			talosclient.WithEndpoints(endpoint),
 			talosclient.WithTLSConfig(&tls.Config{
 				InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance mode machines
 			}),
@@ -353,7 +353,7 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 				ServerName:   cr.Spec.ForProvider.Node, // Use node IP as server name
 				MinVersion:   tls.VersionTLS12,
 			}))),
-			talosclient.WithEndpoints(endpoints...),
+			talosclient.WithEndpoints(endpoint),
 		)
 	}
 	if err != nil {
@@ -372,6 +372,15 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 
 	fmt.Printf("Successfully applied configuration to node %s\n", cr.Spec.ForProvider.Node)
 	return nil
+}
+
+func getConfigurationApplyEndpoint(cr *v1alpha1.ConfigurationApply) string {
+	endpoint := cr.Spec.ForProvider.Node + ":50000"
+	if cr.Spec.ForProvider.Endpoint != nil && *cr.Spec.ForProvider.Endpoint != "" {
+		endpoint = *cr.Spec.ForProvider.Endpoint
+	}
+
+	return endpoint
 }
 
 // generateMachineConfigurationYAML converts structured configuration to Talos machine configuration YAML

--- a/internal/controller/configurationapply/configurationapply_test.go
+++ b/internal/controller/configurationapply/configurationapply_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	v1alpha1 "github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -68,6 +69,57 @@ func TestObserve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetConfigurationApplyEndpoint(t *testing.T) {
+	node := "127.0.0.2"
+	customEndpoint := "127.0.0.1:50000"
+	emptyEndpoint := ""
+
+	tests := map[string]struct {
+		cr   *v1alpha1.ConfigurationApply
+		want string
+	}{
+		"DefaultsToNodePort": {
+			cr: &v1alpha1.ConfigurationApply{
+				Spec: v1alpha1.ConfigurationApplySpec{
+					ForProvider: v1alpha1.ConfigurationApplyParameters{Node: node},
+				},
+			},
+			want: node + ":50000",
+		},
+		"UsesProvidedEndpoint": {
+			cr: &v1alpha1.ConfigurationApply{
+				Spec: v1alpha1.ConfigurationApplySpec{
+					ForProvider: v1alpha1.ConfigurationApplyParameters{
+						Node:     node,
+						Endpoint: &customEndpoint,
+					},
+				},
+			},
+			want: customEndpoint,
+		},
+		"IgnoresEmptyEndpoint": {
+			cr: &v1alpha1.ConfigurationApply{
+				Spec: v1alpha1.ConfigurationApplySpec{
+					ForProvider: v1alpha1.ConfigurationApplyParameters{
+						Node:     node,
+						Endpoint: &emptyEndpoint,
+					},
+				},
+			},
+			want: node + ":50000",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := getConfigurationApplyEndpoint(tc.cr)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("getConfigurationApplyEndpoint(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

What changed:
- internal/controller/configurationapply/configurationapply.go
  - ConfigurationApply now uses spec.forProvider.endpoint when set.
  - Falls back to node + ":50000" when endpoint is unset or empty.
- internal/controller/configurationapply/configurationapply_test.go
  - Added focused unit tests for endpoint selection behavior.
 
fixes https://github.com/crossplane-contrib/provider-talos/issues/6

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Unit tests
- Ran reproduction steps from initial issue against locally running provider and observed that the server attempted to dial `127.0.0.1:50000` as configured as the `endpoint`.

[contribution process]: https://git.io/fj2m9
