### PR TITLE
Fix ConfigurationApply inline TLS handling

### DIFF
--- a/internal/controller/configurationapply/configurationapply.go
+++ b/internal/controller/configurationapply/configurationapply.go
@@ -19,6 +19,7 @@ package configurationapply
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -26,8 +27,6 @@ import (
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 
@@ -381,20 +380,15 @@ func (c *external) canConnectInsecure(ctx context.Context, cr *v1alpha1.Configur
 
 // canConnectWithCreds checks if the machine accepts authenticated connections (configured mode)
 func (c *external) canConnectWithCreds(ctx context.Context, cr *v1alpha1.ConfigurationApply) bool {
-	clientConfig := cr.Spec.ForProvider.ClientConfiguration
 	endpoint := getConfigurationApplyEndpoint(cr)
 
-	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
+	tlsConfig, err := buildConfigurationApplyTLSConfig(cr.Spec.ForProvider.ClientConfiguration, cr.Spec.ForProvider.Node)
 	if err != nil {
 		return false
 	}
 
 	talosClient, err := talosclient.New(ctx,
-		talosclient.WithGRPCDialOptions(grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{cert},
-			ServerName:   cr.Spec.ForProvider.Node,
-			MinVersion:   tls.VersionTLS12,
-		}))),
+		talosclient.WithTLSConfig(tlsConfig),
 		talosclient.WithEndpoints(endpoint),
 	)
 	if err != nil {
@@ -427,43 +421,33 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 	clientConfig := cr.Spec.ForProvider.ClientConfiguration
 	endpoint := getConfigurationApplyEndpoint(cr)
 
-	var talosClient *talosclient.Client
-
-	if clientConfig.ClientCertificate == "" || clientConfig.ClientCertificate == "insecure" {
-		// Use insecure gRPC connection for machines in maintenance mode
-		fmt.Printf("Using insecure gRPC connection for maintenance mode machine\n")
-		talosClient, err = talosclient.New(ctx,
-			talosclient.WithEndpoints(endpoint),
-			talosclient.WithTLSConfig(&tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance mode machines
-			}),
-		)
-	} else {
-		// Create a certificate from the provided certificates
-		cert, certErr := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
-		if certErr != nil {
-			return errors.Wrap(certErr, "failed to create client certificate")
-		}
-
-		fmt.Printf("Using secure TLS connection with client certificates\n")
-		talosClient, err = talosclient.New(ctx,
-			talosclient.WithGRPCDialOptions(grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-				Certificates: []tls.Certificate{cert},
-				ServerName:   cr.Spec.ForProvider.Node, // Use node IP as server name
-				MinVersion:   tls.VersionTLS12,
-			}))),
-			talosclient.WithEndpoints(endpoint),
-		)
+	tlsConfig, err := buildConfigurationApplyTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
+	if err != nil {
+		return err
 	}
+	if tlsConfig.InsecureSkipVerify {
+		fmt.Printf("Using insecure gRPC connection for maintenance mode machine\n")
+	} else {
+		fmt.Printf("Using secure TLS connection with client certificates\n")
+	}
+	talosClient, err := talosclient.New(ctx,
+		talosclient.WithTLSConfig(tlsConfig),
+		talosclient.WithEndpoints(endpoint),
+	)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Talos client")
 	}
 	defer talosClient.Close() // nolint:errcheck
 
 	// Apply the configuration to the node
+	mode, err := getConfigurationApplyMode(cr.Spec.ForProvider.ApplyMode)
+	if err != nil {
+		return err
+	}
+
 	_, err = talosClient.ApplyConfiguration(ctx, &machine.ApplyConfigurationRequest{
 		Data: []byte(configInput),
-		Mode: machine.ApplyConfigurationRequest_REBOOT, // Required for maintenance mode
+		Mode: mode,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to apply configuration to Talos node")
@@ -473,6 +457,35 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 	return nil
 }
 
+func buildConfigurationApplyTLSConfig(clientConfig v1alpha1.ClientConfiguration, node string) (*tls.Config, error) {
+	if clientConfig.ClientCertificate == "" || clientConfig.ClientCertificate == "insecure" {
+		return &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance mode machines.
+		}, nil
+	}
+
+	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client certificate")
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ServerName:   node,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if clientConfig.CACertificate != "" && clientConfig.CACertificate != "insecure" {
+		roots := x509.NewCertPool()
+		if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = roots
+	}
+
+	return tlsConfig, nil
+}
+
 func getConfigurationApplyEndpoint(cr *v1alpha1.ConfigurationApply) string {
 	endpoint := cr.Spec.ForProvider.Node + ":50000"
 	if cr.Spec.ForProvider.Endpoint != nil && *cr.Spec.ForProvider.Endpoint != "" {
@@ -480,6 +493,23 @@ func getConfigurationApplyEndpoint(cr *v1alpha1.ConfigurationApply) string {
 	}
 
 	return endpoint
+}
+
+func getConfigurationApplyMode(applyMode *string) (machine.ApplyConfigurationRequest_Mode, error) {
+	if applyMode == nil || *applyMode == "" || *applyMode == "reboot" {
+		return machine.ApplyConfigurationRequest_REBOOT, nil
+	}
+
+	switch *applyMode {
+	case "auto":
+		return machine.ApplyConfigurationRequest_AUTO, nil
+	case "no_reboot":
+		return machine.ApplyConfigurationRequest_NO_REBOOT, nil
+	case "staged":
+		return machine.ApplyConfigurationRequest_STAGED, nil
+	default:
+		return machine.ApplyConfigurationRequest_REBOOT, errors.Errorf("unknown configuration apply mode %q", *applyMode)
+	}
 }
 
 // generateMachineConfigurationYAML converts structured configuration to Talos machine configuration YAML

--- a/internal/controller/configurationapply/configurationapply_test.go
+++ b/internal/controller/configurationapply/configurationapply_test.go
@@ -18,9 +18,18 @@ package configurationapply
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 
 	v1alpha1 "github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -69,6 +78,149 @@ func TestObserve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetConfigurationApplyMode(t *testing.T) {
+	empty := ""
+	reboot := "reboot"
+	auto := "auto"
+	noReboot := "no_reboot"
+	staged := "staged"
+	unknown := "unknown"
+
+	tests := map[string]struct {
+		applyMode *string
+		want      machine.ApplyConfigurationRequest_Mode
+		wantErr   bool
+	}{
+		"NilDefaultsToReboot": {
+			want: machine.ApplyConfigurationRequest_REBOOT,
+		},
+		"EmptyDefaultsToReboot": {
+			applyMode: &empty,
+			want:      machine.ApplyConfigurationRequest_REBOOT,
+		},
+		"Reboot": {
+			applyMode: &reboot,
+			want:      machine.ApplyConfigurationRequest_REBOOT,
+		},
+		"Auto": {
+			applyMode: &auto,
+			want:      machine.ApplyConfigurationRequest_AUTO,
+		},
+		"NoReboot": {
+			applyMode: &noReboot,
+			want:      machine.ApplyConfigurationRequest_NO_REBOOT,
+		},
+		"Staged": {
+			applyMode: &staged,
+			want:      machine.ApplyConfigurationRequest_STAGED,
+		},
+		"UnknownErrors": {
+			applyMode: &unknown,
+			want:      machine.ApplyConfigurationRequest_REBOOT,
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := getConfigurationApplyMode(tc.applyMode)
+			if tc.wantErr && err == nil {
+				t.Fatal("getConfigurationApplyMode(...): expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("getConfigurationApplyMode(...): unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("getConfigurationApplyMode(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildConfigurationApplyTLSConfig(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCertificates(t)
+
+	tests := map[string]struct {
+		clientConfig v1alpha1.ClientConfiguration
+		node         string
+		check        func(t *testing.T, cfg *tls.Config)
+		wantErr      bool
+	}{
+		"InsecureEmptyClientCertificate": {
+			clientConfig: v1alpha1.ClientConfiguration{},
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				if !cfg.InsecureSkipVerify {
+					t.Fatal("buildConfigurationApplyTLSConfig(...): InsecureSkipVerify = false")
+				}
+			},
+		},
+		"InsecureClientCertificateValue": {
+			clientConfig: v1alpha1.ClientConfiguration{ClientCertificate: "insecure"},
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				if !cfg.InsecureSkipVerify {
+					t.Fatal("buildConfigurationApplyTLSConfig(...): InsecureSkipVerify = false")
+				}
+			},
+		},
+		"SecureWithCA": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			node: "127.0.0.1",
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				if len(cfg.Certificates) != 1 {
+					t.Fatalf("buildConfigurationApplyTLSConfig(...): got %d certificates, want 1", len(cfg.Certificates))
+				}
+				if cfg.RootCAs == nil {
+					t.Fatal("buildConfigurationApplyTLSConfig(...): RootCAs = nil")
+				}
+				if diff := cmp.Diff("127.0.0.1", cfg.ServerName); diff != "" {
+					t.Errorf("buildConfigurationApplyTLSConfig(...).ServerName: -want, +got:\n%s", diff)
+				}
+				if diff := cmp.Diff(uint16(tls.VersionTLS12), cfg.MinVersion); diff != "" {
+					t.Errorf("buildConfigurationApplyTLSConfig(...).MinVersion: -want, +got:\n%s", diff)
+				}
+			},
+		},
+		"InvalidCAErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     "invalid",
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: true,
+		},
+		"InvalidClientCertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: "invalid",
+				ClientKey:         clientKey,
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildConfigurationApplyTLSConfig(tc.clientConfig, tc.node)
+			if tc.wantErr && err == nil {
+				t.Fatal("buildConfigurationApplyTLSConfig(...): expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("buildConfigurationApplyTLSConfig(...): unexpected error: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, got)
 			}
 		})
 	}
@@ -123,4 +275,50 @@ func TestGetConfigurationApplyEndpoint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func generateTestCertificates(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+
+	return string(caPEM), string(clientCertPEM), string(clientKeyPEM)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!
Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This updates `ConfigurationApply` to support inline Talos client TLS inputs without falling back to the local default talosconfig.
 
The secure `ConfigurationApply` paths now build a Talos TLS config from `spec.forProvider.clientConfiguration` and pass it through `talosclient.WithTLSConfig(...)`. This also honors `clientConfiguration.caCertificate` as a root CA and preserves the existing server name and TLS minimum version behavior.

This PR also maps `spec.forProvider.applyMode` to the corresponding Talos apply mode instead of always sending `REBOOT`.

Fixes https://github.com/crossplane-contrib/provider-talos/issues/8

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested with:
- unit tests 
- Reran reproduction steps from initial issue:

ProviderConfig:

```yaml
apiVersion: talos.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: None
```

ConfigurationApply used generated short-lived CA and client cert/key PEM values. I used `endpoint: 127.0.0.1:1` so the test fails quickly and deterministically after Talos client creation:

```yaml
apiVersion: machine.talos.crossplane.io/v1alpha1
kind: ConfigurationApply
metadata:
  name: inline-config-apply-repro-after-fix
spec:
  providerConfigRef:
    name: default
  forProvider:
    node: 127.0.0.1
    endpoint: 127.0.0.1:1
    applyMode: no_reboot
    clientConfiguration:
      caCertificate: |
        -----BEGIN CERTIFICATE-----
        <generated>
        -----END CERTIFICATE-----
      clientCertificate: |
        -----BEGIN CERTIFICATE-----
        <generated>
        -----END CERTIFICATE-----
      clientKey: |
        -----BEGIN PRIVATE KEY-----
        <generated>
        -----END PRIVATE KEY-----
    machineConfiguration:
      version: v1alpha1
      machine:
        type: controlplane
        token: machine-token
        install:
          disk: /dev/vda
          image: factory.talos.dev/installer/test:v1.11.0
      cluster:
        id: cluster-id
        secret: cluster-secret
        clusterName: repro
        token: cluster-token
        controlPlane:
          endpoint: https://127.0.0.1:6443
        network:
          podSubnets:
          - 10.244.0.0/16
          serviceSubnets:
          - 10.96.0.0/12
```

Relevant provider output:

```text
Observing ConfigurationApply: inline-config-apply-repro-after-fix
Machine 127.0.0.1 is unreachable (installing or failed)
Machine 127.0.0.1 unreachable and configuration not applied
Applying Configuration to Node: 127.0.0.1
Generated configuration YAML (length: 619 bytes)
Using secure TLS connection with client certificates
Cannot create external resource ... "error": "failed to apply configuration to node: failed to apply configuration to Talos node: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:1: connect: connection refused\""
```

Note it's accepted the client certficates and no longer fails with:

```text
failed to resolve configuration context: talos config file is empty
```

[contribution process]: https://git.io/fj2m9