### PR TITLE
Fix ConfigurationApply maintenance first apply

### DIFF
--- a/internal/controller/configurationapply/configurationapply.go
+++ b/internal/controller/configurationapply/configurationapply.go
@@ -167,6 +167,8 @@ type external struct {
 	service interface{}
 	// ProviderConfig credentials for verifying machine state
 	providerConfigData []byte
+	// canConnectInsecureFn allows tests to stub maintenance-mode detection.
+	canConnectInsecureFn func(context.Context, *v1alpha1.ConfigurationApply) bool
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -339,6 +341,10 @@ func (c *external) checkMachineState(ctx context.Context, cr *v1alpha1.Configura
 
 // canConnectInsecure checks if the machine accepts insecure connections (maintenance mode)
 func (c *external) canConnectInsecure(ctx context.Context, cr *v1alpha1.ConfigurationApply) bool {
+	if c.canConnectInsecureFn != nil {
+		return c.canConnectInsecureFn(ctx, cr)
+	}
+
 	endpoint := getConfigurationApplyEndpoint(cr)
 
 	talosClient, err := talosclient.New(ctx,
@@ -417,15 +423,15 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 	// For now, skip config parsing validation
 	// In a complete implementation, this would validate the configuration
 
-	// Create client config - support insecure mode for maintenance mode machines
-	clientConfig := cr.Spec.ForProvider.ClientConfiguration
 	endpoint := getConfigurationApplyEndpoint(cr)
 
-	tlsConfig, err := buildConfigurationApplyTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
+	tlsConfig, maintenanceMode, err := c.buildApplyTLSConfig(ctx, cr)
 	if err != nil {
 		return err
 	}
-	if tlsConfig.InsecureSkipVerify {
+	if maintenanceMode {
+		fmt.Printf("Machine %s is in maintenance mode; using insecure first apply\n", cr.Spec.ForProvider.Node)
+	} else if tlsConfig.InsecureSkipVerify {
 		fmt.Printf("Using insecure gRPC connection for maintenance mode machine\n")
 	} else {
 		fmt.Printf("Using secure TLS connection with client certificates\n")
@@ -455,6 +461,20 @@ func (c *external) applyConfigurationToNode(ctx context.Context, cr *v1alpha1.Co
 
 	fmt.Printf("Successfully applied configuration to node %s\n", cr.Spec.ForProvider.Node)
 	return nil
+}
+
+func (c *external) buildApplyTLSConfig(ctx context.Context, cr *v1alpha1.ConfigurationApply) (*tls.Config, bool, error) {
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	if c.canConnectInsecure(checkCtx, cr) {
+		return &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for Talos maintenance-mode first apply.
+		}, true, nil
+	}
+
+	tlsConfig, err := buildConfigurationApplyTLSConfig(cr.Spec.ForProvider.ClientConfiguration, cr.Spec.ForProvider.Node)
+	return tlsConfig, false, err
 }
 
 func buildConfigurationApplyTLSConfig(clientConfig v1alpha1.ClientConfiguration, node string) (*tls.Config, error) {

--- a/internal/controller/configurationapply/configurationapply_test.go
+++ b/internal/controller/configurationapply/configurationapply_test.go
@@ -226,6 +226,112 @@ func TestBuildConfigurationApplyTLSConfig(t *testing.T) {
 	}
 }
 
+func TestBuildApplyTLSConfig(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCertificates(t)
+
+	tests := map[string]struct {
+		maintenanceMode bool
+		clientConfig    v1alpha1.ClientConfiguration
+		check           func(t *testing.T, cfg *tls.Config, maintenanceMode bool)
+		wantErr         bool
+	}{
+		"MaintenanceModeUsesInsecureTLSWithInlineClientConfiguration": {
+			maintenanceMode: true,
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			check: func(t *testing.T, cfg *tls.Config, maintenanceMode bool) {
+				t.Helper()
+				if !maintenanceMode {
+					t.Fatal("buildApplyTLSConfig(...): maintenanceMode = false")
+				}
+				if !cfg.InsecureSkipVerify {
+					t.Fatal("buildApplyTLSConfig(...): InsecureSkipVerify = false")
+				}
+				if len(cfg.Certificates) != 0 {
+					t.Fatalf("buildApplyTLSConfig(...): got %d certificates, want 0", len(cfg.Certificates))
+				}
+			},
+		},
+		"SecureFallbackUsesInlineClientConfiguration": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			check: func(t *testing.T, cfg *tls.Config, maintenanceMode bool) {
+				t.Helper()
+				if maintenanceMode {
+					t.Fatal("buildApplyTLSConfig(...): maintenanceMode = true")
+				}
+				if cfg.InsecureSkipVerify {
+					t.Fatal("buildApplyTLSConfig(...): InsecureSkipVerify = true")
+				}
+				if len(cfg.Certificates) != 1 {
+					t.Fatalf("buildApplyTLSConfig(...): got %d certificates, want 1", len(cfg.Certificates))
+				}
+				if cfg.RootCAs == nil {
+					t.Fatal("buildApplyTLSConfig(...): RootCAs = nil")
+				}
+				if diff := cmp.Diff("127.0.0.1", cfg.ServerName); diff != "" {
+					t.Errorf("buildApplyTLSConfig(...).ServerName: -want, +got:\n%s", diff)
+				}
+			},
+		},
+		"ExplicitInsecureFallbackPreservesExistingBehavior": {
+			clientConfig: v1alpha1.ClientConfiguration{ClientCertificate: "insecure"},
+			check: func(t *testing.T, cfg *tls.Config, maintenanceMode bool) {
+				t.Helper()
+				if maintenanceMode {
+					t.Fatal("buildApplyTLSConfig(...): maintenanceMode = true")
+				}
+				if !cfg.InsecureSkipVerify {
+					t.Fatal("buildApplyTLSConfig(...): InsecureSkipVerify = false")
+				}
+			},
+		},
+		"InvalidSecureClientConfigurationErrorsAfterMaintenanceProbeFails": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     "invalid",
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := external{
+				canConnectInsecureFn: func(context.Context, *v1alpha1.ConfigurationApply) bool {
+					return tc.maintenanceMode
+				},
+			}
+			cr := &v1alpha1.ConfigurationApply{
+				Spec: v1alpha1.ConfigurationApplySpec{
+					ForProvider: v1alpha1.ConfigurationApplyParameters{
+						Node:                "127.0.0.1",
+						ClientConfiguration: tc.clientConfig,
+					},
+				},
+			}
+
+			got, maintenanceMode, err := e.buildApplyTLSConfig(context.Background(), cr)
+			if tc.wantErr && err == nil {
+				t.Fatal("buildApplyTLSConfig(...): expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("buildApplyTLSConfig(...): unexpected error: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, got, maintenanceMode)
+			}
+		})
+	}
+}
+
 func TestGetConfigurationApplyEndpoint(t *testing.T) {
 	node := "127.0.0.2"
 	customEndpoint := "127.0.0.1:50000"


### PR DESCRIPTION
### Description of your changes
This updates `ConfigurationApply` to probe for Talos maintenance mode immediately before applying machine configuration. If the node accepts the insecure maintenance-mode connection, the first apply uses the insecure Talos client path even when inline client certificate configuration is present. If the maintenance probe fails, the controller falls back to the existing secure mTLS client configuration path.

Fixes #10

I have:
- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Added unit coverage for pre-apply TLS selection, including maintenance-mode insecure apply with inline client certs, secure fallback behavior, explicit insecure fallback behavior, and invalid secure client configuration errors.
Ran:
```sh
go test ./internal/controller/configurationapply
```

Reproduction locally as seen in the issue: https://gist.github.com/danieldides/ce95aeba6ad98d2bed0dd37a8b147e6b

[contribution process]: https://git.io/fj2m9