### PR TITLE
Fix ConfigurationApply retry and Talos client credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/siderolabs/talos/pkg/machinery v1.11.0
 	google.golang.org/grpc v1.73.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	k8s.io/api v0.31.2
 	k8s.io/apimachinery v0.31.2
 	k8s.io/client-go v0.31.2
 	sigs.k8s.io/controller-runtime v0.19.0
@@ -120,7 +121,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.31.2 // indirect
 	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/component-base v0.31.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/internal/controller/configurationapply/configurationapply.go
+++ b/internal/controller/configurationapply/configurationapply.go
@@ -40,6 +40,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -181,49 +182,35 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	// Check the actual state of the machine
 	machineState := c.checkMachineState(ctx, cr)
+	applied := resolveAppliedStatus(cr)
 
 	// Update status with detected machine state
 	now := metav1.Now()
 	cr.Status.AtProvider.MachineState = string(machineState)
 	cr.Status.AtProvider.LastStateCheck = &now
 
-	// Check if we have a valid machine configuration from structured fields
-	hasValidConfig := cr.Spec.ForProvider.MachineConfiguration.Version != "" &&
-		cr.Spec.ForProvider.MachineConfiguration.Machine.Type != "" &&
-		cr.Spec.ForProvider.MachineConfiguration.Machine.Token != "" &&
-		cr.Spec.ForProvider.MachineConfiguration.Cluster.ID != ""
-
-	// Determine resource state based on machine state
-	var resourceExists, resourceUpToDate bool
+	resourceExists, resourceUpToDate := observationState(machineState, applied, hasValidMachineConfig(cr))
 
 	switch machineState {
 	case MachineStateMaintenanceMode:
-		// Machine is in maintenance mode - configuration needs to be applied
-		resourceExists = false
-		resourceUpToDate = false
-		cr.Status.AtProvider.Applied = false
-		fmt.Printf("Machine %s in maintenance mode - configuration not applied\n", cr.Spec.ForProvider.Node)
+		if applied {
+			cr.SetConditions(xpv1.Available())
+			fmt.Printf("Machine %s in maintenance mode but configuration was applied\n", cr.Spec.ForProvider.Node)
+		} else {
+			cr.Status.AtProvider.Applied = false
+			fmt.Printf("Machine %s in maintenance mode - configuration not applied\n", cr.Spec.ForProvider.Node)
+		}
 
 	case MachineStateConfigured:
-		// Machine is configured and running - verified with authenticated connection
-		resourceExists = true
-		resourceUpToDate = hasValidConfig
 		cr.Status.AtProvider.Applied = true
 		cr.SetConditions(xpv1.Available())
 		fmt.Printf("Machine %s is configured and running\n", cr.Spec.ForProvider.Node)
 
 	case MachineStateUnreachable:
-		// Machine is unreachable - could be installing or failed
-		if cr.Status.AtProvider.Applied {
-			// We previously applied config - assume it's installing/rebooting (expected)
-			resourceExists = true
-			resourceUpToDate = hasValidConfig
+		if applied {
 			cr.SetConditions(xpv1.Available())
 			fmt.Printf("Machine %s unreachable but configuration was applied - likely installing\n", cr.Spec.ForProvider.Node)
 		} else {
-			// Never applied config and unreachable - needs configuration
-			resourceExists = false
-			resourceUpToDate = false
 			fmt.Printf("Machine %s unreachable and configuration not applied\n", cr.Spec.ForProvider.Node)
 		}
 	}
@@ -233,6 +220,45 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		ResourceUpToDate:  resourceUpToDate,
 		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
+}
+
+func resolveAppliedStatus(cr *v1alpha1.ConfigurationApply) bool {
+	applied := cr.Status.AtProvider.Applied || hasSuccessfulExternalCreate(cr)
+	if applied && !cr.Status.AtProvider.Applied {
+		cr.Status.AtProvider.Applied = true
+	}
+	if applied && cr.Status.AtProvider.LastAppliedTime == nil {
+		if t := meta.GetExternalCreateSucceeded(cr); !t.IsZero() {
+			lastApplied := metav1.NewTime(t)
+			cr.Status.AtProvider.LastAppliedTime = &lastApplied
+		}
+	}
+
+	return applied
+}
+
+func hasValidMachineConfig(cr *v1alpha1.ConfigurationApply) bool {
+	return cr.Spec.ForProvider.MachineConfiguration.Version != "" &&
+		cr.Spec.ForProvider.MachineConfiguration.Machine.Type != "" &&
+		cr.Spec.ForProvider.MachineConfiguration.Machine.Token != "" &&
+		cr.Spec.ForProvider.MachineConfiguration.Cluster.ID != ""
+}
+
+func observationState(machineState MachineState, applied, hasValidConfig bool) (bool, bool) {
+	switch machineState {
+	case MachineStateMaintenanceMode:
+		return applied, applied && hasValidConfig
+	case MachineStateConfigured:
+		return true, hasValidConfig
+	case MachineStateUnreachable:
+		return applied, applied && hasValidConfig
+	}
+
+	return false, false
+}
+
+func hasSuccessfulExternalCreate(cr *v1alpha1.ConfigurationApply) bool {
+	return cr.GetAnnotations()[meta.AnnotationKeyExternalCreateSucceeded] != ""
 }
 
 func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
@@ -251,7 +277,8 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	// Update status
 	cr.Status.AtProvider.Applied = true
-	// Note: LastAppliedTime field doesn't exist in the generated API, skipping
+	now := metav1.Now()
+	cr.Status.AtProvider.LastAppliedTime = &now
 
 	// Set Ready condition since configuration was successfully applied
 	cr.SetConditions(xpv1.Available())
@@ -279,7 +306,8 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	// Update status
 	cr.Status.AtProvider.Applied = true
-	// Note: LastAppliedTime field doesn't exist in the generated API, skipping
+	now := metav1.Now()
+	cr.Status.AtProvider.LastAppliedTime = &now
 
 	return managed.ExternalUpdate{
 		ConnectionDetails: managed.ConnectionDetails{},

--- a/internal/controller/configurationapply/configurationapply_test.go
+++ b/internal/controller/configurationapply/configurationapply_test.go
@@ -28,8 +28,12 @@ import (
 	"testing"
 	"time"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/google/go-cmp/cmp"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -80,6 +84,104 @@ func TestObserve(t *testing.T) {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
+	}
+}
+
+func TestObserveUnreachableWithSuccessfulExternalCreate(t *testing.T) {
+	createdAt := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	cr := testConfigurationApply()
+	meta.SetExternalCreateSucceeded(cr, createdAt)
+
+	e := external{canConnectInsecureFn: func(context.Context, *v1alpha1.ConfigurationApply) bool { return false }}
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if !got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = false, want true")
+	}
+	if !got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = false, want true")
+	}
+	if !cr.Status.AtProvider.Applied {
+		t.Fatal("cr.Status.AtProvider.Applied = false, want true")
+	}
+	if cr.Status.AtProvider.LastAppliedTime == nil || !cr.Status.AtProvider.LastAppliedTime.Time.Equal(createdAt) {
+		t.Fatalf("cr.Status.AtProvider.LastAppliedTime = %v, want %v", cr.Status.AtProvider.LastAppliedTime, createdAt)
+	}
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got != corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want %s", got, corev1.ConditionTrue)
+	}
+}
+
+func TestObserveUnreachableWithoutSuccessfulExternalCreate(t *testing.T) {
+	cr := testConfigurationApply()
+	e := external{canConnectInsecureFn: func(context.Context, *v1alpha1.ConfigurationApply) bool { return false }}
+
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = true, want false")
+	}
+	if got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = true, want false")
+	}
+	if cr.Status.AtProvider.Applied {
+		t.Fatal("cr.Status.AtProvider.Applied = true, want false")
+	}
+}
+
+func TestObserveMaintenanceModeKeepsSuccessfulExternalCreate(t *testing.T) {
+	cr := testConfigurationApply()
+	meta.SetExternalCreateSucceeded(cr, time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC))
+	e := external{canConnectInsecureFn: func(context.Context, *v1alpha1.ConfigurationApply) bool { return true }}
+
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if !got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = false, want true")
+	}
+	if !got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = false, want true")
+	}
+	if !cr.Status.AtProvider.Applied {
+		t.Fatal("cr.Status.AtProvider.Applied = false, want true")
+	}
+}
+
+func testConfigurationApply() *v1alpha1.ConfigurationApply {
+	return &v1alpha1.ConfigurationApply{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-apply"},
+		Spec: v1alpha1.ConfigurationApplySpec{ForProvider: v1alpha1.ConfigurationApplyParameters{
+			Node: "127.0.0.1",
+			MachineConfiguration: v1alpha1.MachineConfigurationSpec{
+				Version: "v1alpha1",
+				Machine: v1alpha1.MachineSpec{
+					Type:  "controlplane",
+					Token: "machine-token",
+					Install: v1alpha1.InstallSpec{
+						Disk:  "/dev/sda",
+						Image: "ghcr.io/siderolabs/installer:v1.11.0",
+					},
+				},
+				Cluster: v1alpha1.ClusterSpec{
+					ID:          "cluster-id",
+					Secret:      "cluster-secret",
+					ClusterName: "test-cluster",
+					ControlPlane: v1alpha1.ControlPlaneSpec{
+						Endpoint: "https://127.0.0.1:6443",
+					},
+					Token: "cluster-token",
+				},
+			},
+		}},
 	}
 }
 

--- a/internal/controller/secrets/secrets.go
+++ b/internal/controller/secrets/secrets.go
@@ -42,6 +42,8 @@ import (
 	"github.com/crossplane-contrib/provider-talos/internal/features"
 
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/siderolabs/talos/pkg/machinery/role"
 )
 
 const (
@@ -327,6 +329,10 @@ func (c *external) generateMachineSecrets(talosVersion *string) (*GeneratedSecre
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate secrets bundle")
 	}
+	clientCertificate, err := secretsBundle.GenerateTalosAPIClientCertificateWithTTL(role.MakeSet(role.Admin), constants.TalosAPIDefaultCertificateValidityDuration)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate Talos API client certificate")
+	}
 
 	// Extract cluster secrets as JSON
 	clusterSecretsData := map[string]interface{}{
@@ -369,8 +375,8 @@ func (c *external) generateMachineSecrets(talosVersion *string) (*GeneratedSecre
 		"contexts": map[string]interface{}{
 			"default": map[string]interface{}{
 				"ca":  string(secretsBundle.Certs.OS.Crt),
-				"crt": string(secretsBundle.Certs.OS.Crt),
-				"key": string(secretsBundle.Certs.OS.Key),
+				"crt": string(clientCertificate.Crt),
+				"key": string(clientCertificate.Key),
 			},
 		},
 	}
@@ -384,8 +390,8 @@ func (c *external) generateMachineSecrets(talosVersion *string) (*GeneratedSecre
 		KubernetesSecrets: string(kubernetesSecretsJSON),
 		TrustdInfo:        string(trustdInfoJSON),
 		CACertificate:     string(secretsBundle.Certs.OS.Crt),
-		ClientCertificate: string(secretsBundle.Certs.OS.Crt),
-		ClientKey:         string(secretsBundle.Certs.OS.Key),
+		ClientCertificate: string(clientCertificate.Crt),
+		ClientKey:         string(clientCertificate.Key),
 		TalosConfig:       talosConfigBytes,
 	}, nil
 }

--- a/internal/controller/secrets/secrets_test.go
+++ b/internal/controller/secrets/secrets_test.go
@@ -18,6 +18,9 @@ package secrets
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -71,4 +74,79 @@ func TestObserve(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateMachineSecretsUsesAdminClientCertificate(t *testing.T) {
+	generated, err := (&external{}).generateMachineSecrets(nil)
+	if err != nil {
+		t.Fatalf("generateMachineSecrets(...): unexpected error: %v", err)
+	}
+
+	if generated.ClientCertificate == generated.CACertificate {
+		t.Fatal("ClientCertificate matches CACertificate, want generated leaf certificate")
+	}
+
+	clientCert := parseCertificate(t, generated.ClientCertificate)
+	if clientCert.IsCA {
+		t.Fatal("ClientCertificate IsCA = true, want false")
+	}
+	if diff := cmp.Diff([]string{"os:admin"}, clientCert.Subject.Organization); diff != "" {
+		t.Errorf("ClientCertificate Subject.Organization: -want, +got:\n%s", diff)
+	}
+	if !hasClientAuthUsage(clientCert) {
+		t.Fatal("ClientCertificate missing ExtKeyUsageClientAuth")
+	}
+
+	caCert := parseCertificate(t, generated.CACertificate)
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+	if _, err := clientCert.Verify(x509.VerifyOptions{Roots: roots, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		t.Fatalf("ClientCertificate did not verify against CACertificate: %v", err)
+	}
+
+	var talosConfig struct {
+		Contexts map[string]struct {
+			CA  string `json:"ca"`
+			Crt string `json:"crt"`
+			Key string `json:"key"`
+		} `json:"contexts"`
+	}
+	if err := json.Unmarshal(generated.TalosConfig, &talosConfig); err != nil {
+		t.Fatalf("TalosConfig JSON unmarshal failed: %v", err)
+	}
+	ctx, ok := talosConfig.Contexts["default"]
+	if !ok {
+		t.Fatal("TalosConfig missing default context")
+	}
+	if diff := cmp.Diff(generated.CACertificate, ctx.CA); diff != "" {
+		t.Errorf("TalosConfig CA: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(generated.ClientCertificate, ctx.Crt); diff != "" {
+		t.Errorf("TalosConfig client certificate: -want, +got:\n%s", diff)
+	}
+	if diff := cmp.Diff(generated.ClientKey, ctx.Key); diff != "" {
+		t.Errorf("TalosConfig client key: -want, +got:\n%s", diff)
+	}
+}
+
+func parseCertificate(t *testing.T, certPEM string) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		t.Fatal("failed to decode certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}
+
+func hasClientAuthUsage(cert *x509.Certificate) bool {
+	for _, usage := range cert.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageClientAuth {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This pull request fixes `ConfigurationApply` convergence after the initial insecure maintenance-mode apply by preserving successful apply state through the expected reboot/unreachable window. It also updates generated Talos client credentials to use a real Talos API admin client certificate instead of reusing the OS CA certificate as the client certificate.

Fixes #13

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added tests covering maintenance-mode first apply retry behavior and generated client credential validity.

Tested in my EKS cluster that I initially observed the issue in. With these latest changes:

```
Machine 15.200.116.30 is in maintenance mode (insecure connection succeeded)
Machine 15.200.116.30 in maintenance mode - configuration not applied
Applying Configuration to Node: 15.200.116.30
Machine 15.200.116.30 is in maintenance mode; using insecure first apply
Successfully applied configuration to node 15.200.116.30
Successfully marked ConfigurationApply as applied: aws-talos-default-test-controlplane-apply-0
Machine 15.200.116.30 is unreachable (installing or failed)
Machine 15.200.116.30 unreachable but configuration was applied - likely installing
```

That last line is the key difference from the broken behavior described in issue #13.

Also, the live `ConfigurationApply `status showed:
```
- applied: true
- Ready=Available
- Synced=ReconcileSuccess
```
So the successful apply state is now durable enough for the observe path


[contribution process]: https://git.io/fj2m9