### PR TITLE
feat(configuration): publish generated machine config

### DIFF
--- a/apis/machine/v1alpha1/configuration_types.go
+++ b/apis/machine/v1alpha1/configuration_types.go
@@ -36,8 +36,9 @@ type ConfigurationParameters struct {
 	MachineType string `json:"machineType"`
 	// ClusterEndpoint is the Kubernetes API endpoint (required)
 	ClusterEndpoint string `json:"clusterEndpoint"`
-	// MachineSecretsRef references the machine secrets
-	MachineSecretsRef *xpv1.Reference `json:"machineSecretsRef,omitempty"`
+	// MachineSecretsRef references the machine secrets used to generate deterministic configuration.
+	// +kubebuilder:validation:Required
+	MachineSecretsRef *xpv1.Reference `json:"machineSecretsRef"`
 	// TalosVersion is the Talos version (optional)
 	// +optional
 	TalosVersion *string `json:"talosVersion,omitempty"`
@@ -53,6 +54,8 @@ type ConfigurationParameters struct {
 type ConfigurationObservation struct {
 	// MachineConfiguration is the generated Talos configuration
 	MachineConfiguration string `json:"machineConfiguration,omitempty"`
+	// MachineConfigurationHash is the SHA-256 hash of the generated Talos configuration
+	MachineConfigurationHash string `json:"machineConfigurationHash,omitempty"`
 	// GeneratedTime is when the configuration was generated
 	GeneratedTime *metav1.Time `json:"generatedTime,omitempty"`
 }

--- a/apis/machine/v1alpha1/secrets_types.go
+++ b/apis/machine/v1alpha1/secrets_types.go
@@ -47,6 +47,8 @@ type ClientConfiguration struct {
 
 // MachineSecretsData contains the generated machine secrets
 type MachineSecretsData struct {
+	// Bundle contains the full Talos machine secrets bundle in JSON format
+	Bundle string `json:"bundle,omitempty"`
 	// ClusterSecrets contains cluster-wide secrets in JSON format
 	ClusterSecrets string `json:"clusterSecrets,omitempty"`
 	// KubernetesSecrets contains Kubernetes-specific secrets in JSON format

--- a/examples/complete-setup/configuration.yaml
+++ b/examples/complete-setup/configuration.yaml
@@ -8,6 +8,8 @@ spec:
     clusterName: demo-cluster
     machineType: worker
     clusterEndpoint: https://192.168.120.87:6443
+    machineSecretsRef:
+      name: cluster-secrets
     talosVersion: v1.8.0
   providerConfigRef:
     name: default

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gertd/go-pluralize v0.2.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -118,6 +119,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250715232539-7130f93afb79 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250715232539-7130f93afb79 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/controller/configuration/configuration.go
+++ b/internal/controller/configuration/configuration.go
@@ -18,14 +18,25 @@ package configuration
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate"
+	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -49,6 +60,8 @@ const (
 	errGetCreds         = "cannot get credentials"
 
 	errNewClient = "cannot create new Service"
+
+	connectionKeyMachineConfiguration = "machine_configuration"
 )
 
 // TalosConfigurationService manages Talos machine configurations
@@ -155,12 +168,13 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errNewClient)
 	}
 
-	return &external{service: svc.(*TalosConfigurationService)}, nil
+	return &external{kube: c.kube, service: svc.(*TalosConfigurationService)}, nil
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
 // external resource to ensure it reflects the managed resource's desired state.
 type external struct {
+	kube    client.Client
 	service *TalosConfigurationService
 }
 
@@ -181,6 +195,10 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	// Update status with generated configuration
 	cr.Status.AtProvider.MachineConfiguration = machineConfig
+	now := metav1.Now()
+	cr.Status.AtProvider.GeneratedTime = &now
+	hash := sha256.Sum256([]byte(machineConfig))
+	cr.Status.AtProvider.MachineConfigurationHash = hex.EncodeToString(hash[:])
 
 	// Set Ready condition
 	cr.SetConditions(xpv1.Available())
@@ -190,7 +208,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	return managed.ExternalObservation{
 		ResourceExists:    true,
 		ResourceUpToDate:  true,
-		ConnectionDetails: managed.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{connectionKeyMachineConfiguration: []byte(machineConfig)},
 	}, nil
 }
 
@@ -243,137 +261,118 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-// generateMachineConfiguration generates a Talos machine configuration based on the provided spec
-//
-//nolint:unparam // Error return type maintained for future error handling
-func (c *external) generateMachineConfiguration(_ context.Context, cr *machinev1alpha1.Configuration) (string, error) {
-	// Get cluster name - use default if not provided
+// generateMachineConfiguration renders Talos machine configuration with the Talos SDK.
+func (c *external) generateMachineConfiguration(ctx context.Context, cr *machinev1alpha1.Configuration) (string, error) {
+	clusterName, clusterEndpoint, kubernetesVersion := configurationInput(cr)
+	options, err := c.generationOptions(ctx, cr)
+	if err != nil {
+		return "", err
+	}
+
+	input, err := generate.NewInput(clusterName, clusterEndpoint, kubernetesVersion, options...)
+	if err != nil {
+		return "", err
+	}
+
+	machineType, err := machine.ParseType(cr.Spec.ForProvider.MachineType)
+	if err != nil {
+		return "", err
+	}
+
+	config, err := input.Config(machineType)
+	if err != nil {
+		return "", err
+	}
+
+	return renderMachineConfig(config, cr.Spec.ForProvider.ConfigPatches)
+}
+
+func configurationInput(cr *machinev1alpha1.Configuration) (string, string, string) {
 	clusterName := "talos-cluster"
 	if cr.Spec.ForProvider.ClusterName != "" {
 		clusterName = cr.Spec.ForProvider.ClusterName
 	}
 
-	// Get cluster endpoint - use provided endpoint or default
 	clusterEndpoint := "https://192.168.120.83:6443"
 	if cr.Spec.ForProvider.ClusterEndpoint != "" {
 		clusterEndpoint = cr.Spec.ForProvider.ClusterEndpoint
 	}
 
-	// For now, generate a basic working Talos configuration
-	// This is a minimal control plane configuration that will work with the machine
-	machineConfig := fmt.Sprintf(`# Talos machine configuration
-version: v1alpha1
-debug: false
-persist: true
-machine:
-  type: controlplane
-  token: wlzjnq.6ac5m9oibqwlkuuy
-  ca:
-    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
-    key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0=
-  certSANs: []
-  kubelet:
-    image: ghcr.io/siderolabs/kubelet:v1.30.7
-    defaultRuntimeSeccompProfileEnabled: true
-    disableManifestsDirectory: true
-  network: {}
-  install:
-    disk: /dev/sda
-    image: ghcr.io/siderolabs/installer:latest
-    wipe: false
-  sysctls: {}
-  sysfs: {}
-  registries: {}
-  features:
-    rbac: true
-    stableHostname: true
-    apidCheckExtKeyUsage: true
-    diskQuotaSupport: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: false
-      resolveMemberNames: true
-cluster:
-  id: %s
-  secret: %s
-  controlPlane:
-    endpoint: %s
-  clusterName: %s
-  network:
-    dnsDomain: cluster.local
-    podSubnets:
-      - 10.244.0.0/16
-    serviceSubnets:
-      - 10.96.0.0/12
-  token: %s
-  secretboxEncryptionSecret: ""
-  ca:
-    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
-    key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0=
-  aggregatorCA:
-    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
-    key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0=
-  serviceAccount:
-    key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0=
-  apiServer:
-    image: registry.k8s.io/kube-apiserver:v1.30.7
-    extraArgs: {}
-    extraVolumes: []
-    env: {}
-    certSANs: []
-    disablePodSecurityPolicy: true
-    admissionControl: []
-    auditPolicy: {}
-  controllerManager:
-    image: registry.k8s.io/kube-controller-manager:v1.30.7
-    extraArgs: {}
-    extraVolumes: []
-    env: {}
-  proxy:
-    disabled: false
-    image: registry.k8s.io/kube-proxy:v1.30.7
-    mode: ipvs
-    extraArgs: {}
-  scheduler:
-    image: registry.k8s.io/kube-scheduler:v1.30.7
-    extraArgs: {}
-    extraVolumes: []
-    env: {}
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  etcd:
-    image: gcr.io/etcd-development/etcd:v3.5.13
-    ca:
-      crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
-      key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0=
-    extraArgs: {}
-    advertisedSubnets: []
-  coreDNS:
-    image: registry.k8s.io/coredns/coredns:v1.11.1
-  externalCloudProvider:
-    enabled: false
-    manifests: []
-  adminKubeconfig:
-    certLifetime: 8760h0m0s
-  allowSchedulingOnMasters: true
-  inlineManifests: []
-  extraManifests: []
-  extraManifestHeaders: {}
-`,
-		"talos-cluster-123",   // cluster.id
-		"cluster-secret-456",  // cluster.secret
-		clusterEndpoint,       // cluster.controlPlane.endpoint
-		clusterName,           // cluster.clusterName
-		"bootstrap-token-789", // cluster.token
-	)
+	kubernetesVersion := constants.DefaultKubernetesVersion
+	if cr.Spec.ForProvider.KubernetesVersion != nil && *cr.Spec.ForProvider.KubernetesVersion != "" {
+		kubernetesVersion = *cr.Spec.ForProvider.KubernetesVersion
+	}
 
-	return machineConfig, nil
+	return clusterName, clusterEndpoint, kubernetesVersion
+}
+
+func (c *external) generationOptions(ctx context.Context, cr *machinev1alpha1.Configuration) ([]generate.Option, error) {
+	options := []generate.Option{}
+	if cr.Spec.ForProvider.TalosVersion != nil && *cr.Spec.ForProvider.TalosVersion != "" {
+		versionContract, err := talosconfig.ParseContractFromVersion(*cr.Spec.ForProvider.TalosVersion)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, generate.WithVersionContract(versionContract))
+	}
+
+	secretsBundle, err := c.getMachineSecretsBundle(ctx, cr)
+	if err != nil {
+		return nil, err
+	}
+	if secretsBundle != nil {
+		options = append(options, generate.WithSecretsBundle(secretsBundle))
+	}
+
+	return options, nil
+}
+
+func renderMachineConfig(config talosconfig.Provider, configPatches []string) (string, error) {
+	if len(configPatches) == 0 {
+		configBytes, err := config.Bytes()
+		return string(configBytes), err
+	}
+
+	patches, err := configpatcher.LoadPatches(configPatches)
+	if err != nil {
+		return "", err
+	}
+
+	patched, err := configpatcher.Apply(configpatcher.WithConfig(config), patches)
+	if err != nil {
+		return "", err
+	}
+
+	configBytes, err := patched.Bytes()
+	if err != nil {
+		return "", err
+	}
+
+	return string(configBytes), nil
+}
+
+func (c *external) getMachineSecretsBundle(ctx context.Context, cr *machinev1alpha1.Configuration) (*talossecrets.Bundle, error) {
+	if cr.Spec.ForProvider.MachineSecretsRef == nil {
+		return nil, errors.New("machineSecretsRef is required to generate deterministic machine configuration")
+	}
+	if c.kube == nil {
+		return nil, errors.New("cannot resolve machineSecretsRef without Kubernetes client")
+	}
+
+	secretsResource := &machinev1alpha1.Secrets{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.Spec.ForProvider.MachineSecretsRef.Name}, secretsResource); err != nil {
+		return nil, errors.Wrap(err, "cannot get referenced machine secrets")
+	}
+
+	if secretsResource.Status.AtProvider.MachineSecrets == nil || secretsResource.Status.AtProvider.MachineSecrets.Bundle == "" {
+		return nil, errors.New("referenced machine secrets do not contain a generated bundle")
+	}
+
+	bundle := &talossecrets.Bundle{Clock: talossecrets.NewClock()}
+	if err := json.Unmarshal([]byte(secretsResource.Status.AtProvider.MachineSecrets.Bundle), bundle); err != nil {
+		return nil, errors.Wrap(err, "cannot decode referenced machine secrets bundle")
+	}
+	bundle.Clock = talossecrets.NewClock()
+
+	return bundle, nil
 }

--- a/internal/controller/configuration/configuration_test.go
+++ b/internal/controller/configuration/configuration_test.go
@@ -18,13 +18,22 @@ package configuration
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	machinev1alpha1 "github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing
@@ -70,5 +79,92 @@ func TestObserve(t *testing.T) {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
 			}
 		})
+	}
+}
+
+func TestObservePublishesMachineConfiguration(t *testing.T) {
+	t.Parallel()
+
+	bundle, err := talossecrets.NewBundle(talossecrets.NewClock(), nil)
+	if err != nil {
+		t.Fatalf("talossecrets.NewBundle(...): %v", err)
+	}
+	bundleJSON, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("json.Marshal(...): %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := machinev1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		t.Fatalf("machinev1alpha1.SchemeBuilder.AddToScheme(...): %v", err)
+	}
+
+	machineSecrets := &machinev1alpha1.Secrets{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-machine-secrets"},
+		Status: machinev1alpha1.SecretsStatus{AtProvider: machinev1alpha1.SecretsObservation{
+			MachineSecrets: &machinev1alpha1.MachineSecretsData{Bundle: string(bundleJSON)},
+		}},
+	}
+
+	configuration := &machinev1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-config"},
+		Spec: machinev1alpha1.ConfigurationSpec{ForProvider: machinev1alpha1.ConfigurationParameters{
+			ClusterName:       "example-cluster",
+			ClusterEndpoint:   "https://10.0.0.1:6443",
+			MachineType:       "worker",
+			MachineSecretsRef: &xpv1.Reference{Name: machineSecrets.Name},
+			ConfigPatches: []string{`machine:
+  nodeLabels:
+    environment: production`},
+		}},
+	}
+
+	e := external{kube: fake.NewClientBuilder().WithScheme(scheme).WithObjects(machineSecrets).Build()}
+	got, err := e.Observe(context.Background(), configuration)
+	if err != nil {
+		t.Fatalf("e.Observe(...): %v", err)
+	}
+
+	machineConfig := string(got.ConnectionDetails[connectionKeyMachineConfiguration])
+	if machineConfig == "" {
+		t.Fatal("expected machine configuration connection detail")
+	}
+	for _, want := range []string{"clusterName: example-cluster", "type: worker", "environment: production"} {
+		if !strings.Contains(machineConfig, want) {
+			t.Fatalf("expected generated machine configuration to contain %q", want)
+		}
+	}
+	if configuration.Status.AtProvider.MachineConfiguration != machineConfig {
+		t.Fatal("expected status machine configuration to match connection detail")
+	}
+	if configuration.Status.AtProvider.MachineConfigurationHash == "" {
+		t.Fatal("expected machine configuration hash in status")
+	}
+	if configuration.Status.AtProvider.GeneratedTime == nil {
+		t.Fatal("expected generated time in status")
+	}
+	if !got.ResourceExists || !got.ResourceUpToDate {
+		t.Fatalf("expected existing and up to date resource, got %+v", got)
+	}
+}
+
+func TestObserveRequiresMachineSecretsRef(t *testing.T) {
+	t.Parallel()
+
+	configuration := &machinev1alpha1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-config"},
+		Spec: machinev1alpha1.ConfigurationSpec{ForProvider: machinev1alpha1.ConfigurationParameters{
+			ClusterName:     "example-cluster",
+			ClusterEndpoint: "https://10.0.0.1:6443",
+			MachineType:     "worker",
+		}},
+	}
+
+	_, err := (&external{}).Observe(context.Background(), configuration)
+	if err == nil {
+		t.Fatal("e.Observe(...): expected error")
+	}
+	if !strings.Contains(err.Error(), "machineSecretsRef is required") {
+		t.Fatalf("e.Observe(...): expected machineSecretsRef required error, got %v", err)
 	}
 }

--- a/internal/controller/secrets/secrets.go
+++ b/internal/controller/secrets/secrets.go
@@ -206,6 +206,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 		// Update the resource status with generated secrets
 		cr.Status.AtProvider.MachineSecrets = &v1alpha1.MachineSecretsData{
+			Bundle:            generatedSecrets.Bundle,
 			ClusterSecrets:    generatedSecrets.ClusterSecrets,
 			KubernetesSecrets: generatedSecrets.KubernetesSecrets,
 			TrustdInfo:        generatedSecrets.TrustdInfo,
@@ -227,6 +228,9 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		connectionDetails["ca_certificate"] = []byte(cr.Status.AtProvider.ClientConfiguration.CACertificate)
 		connectionDetails["client_certificate"] = []byte(cr.Status.AtProvider.ClientConfiguration.ClientCertificate)
 		connectionDetails["client_key"] = []byte(cr.Status.AtProvider.ClientConfiguration.ClientKey)
+	}
+	if cr.Status.AtProvider.MachineSecrets != nil && cr.Status.AtProvider.MachineSecrets.Bundle != "" {
+		connectionDetails["machine_secrets"] = []byte(cr.Status.AtProvider.MachineSecrets.Bundle)
 	}
 
 	// Set Ready condition
@@ -255,6 +259,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	// Update the resource status with generated secrets
 	cr.Status.AtProvider.MachineSecrets = &v1alpha1.MachineSecretsData{
+		Bundle:            generatedSecrets.Bundle,
 		ClusterSecrets:    generatedSecrets.ClusterSecrets,
 		KubernetesSecrets: generatedSecrets.KubernetesSecrets,
 		TrustdInfo:        generatedSecrets.TrustdInfo,
@@ -270,6 +275,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		"ca_certificate":     []byte(generatedSecrets.CACertificate),
 		"client_certificate": []byte(generatedSecrets.ClientCertificate),
 		"client_key":         []byte(generatedSecrets.ClientKey),
+		"machine_secrets":    []byte(generatedSecrets.Bundle),
 		"talos_config":       generatedSecrets.TalosConfig,
 	}
 
@@ -309,6 +315,7 @@ func (c *external) Disconnect(ctx context.Context) error {
 
 // GeneratedSecretsResult contains the generated Talos secrets
 type GeneratedSecretsResult struct {
+	Bundle            string
 	ClusterSecrets    string
 	KubernetesSecrets string
 	TrustdInfo        string
@@ -329,6 +336,11 @@ func (c *external) generateMachineSecrets(talosVersion *string) (*GeneratedSecre
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate secrets bundle")
 	}
+	bundleJSON, err := json.Marshal(secretsBundle)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal secrets bundle")
+	}
+
 	clientCertificate, err := secretsBundle.GenerateTalosAPIClientCertificateWithTTL(role.MakeSet(role.Admin), constants.TalosAPIDefaultCertificateValidityDuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate Talos API client certificate")
@@ -386,6 +398,7 @@ func (c *external) generateMachineSecrets(talosVersion *string) (*GeneratedSecre
 	}
 
 	return &GeneratedSecretsResult{
+		Bundle:            string(bundleJSON),
 		ClusterSecrets:    string(clusterSecretsJSON),
 		KubernetesSecrets: string(kubernetesSecretsJSON),
 		TrustdInfo:        string(trustdInfoJSON),

--- a/package/crds/machine.talos.crossplane.io_configurations.yaml
+++ b/package/crds/machine.talos.crossplane.io_configurations.yaml
@@ -90,6 +90,7 @@ spec:
                     type: string
                   machineSecretsRef:
                     description: MachineSecretsRef references the machine secrets
+                      used to generate deterministic configuration.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -139,6 +140,7 @@ spec:
                 required:
                 - clusterEndpoint
                 - clusterName
+                - machineSecretsRef
                 - machineType
                 - node
                 type: object
@@ -323,6 +325,10 @@ spec:
                     type: string
                   machineConfiguration:
                     description: MachineConfiguration is the generated Talos configuration
+                    type: string
+                  machineConfigurationHash:
+                    description: MachineConfigurationHash is the SHA-256 hash of the
+                      generated Talos configuration
                     type: string
                 type: object
               conditions:

--- a/package/crds/machine.talos.crossplane.io_secrets.yaml
+++ b/package/crds/machine.talos.crossplane.io_secrets.yaml
@@ -276,6 +276,10 @@ spec:
                   machineSecrets:
                     description: MachineSecrets contains the generated secrets structure
                     properties:
+                      bundle:
+                        description: Bundle contains the full Talos machine secrets
+                          bundle in JSON format
+                        type: string
                       clusterSecrets:
                         description: ClusterSecrets contains cluster-wide secrets
                           in JSON format


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #15

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran unit and review checks locally:

- `go test ./internal/controller/configuration -run TestObservePublishesMachineConfiguration -v`
- `go test ./...`
- `make reviewable`

Ran a live local smoke test with Docker, kind, and the provider running externally from this branch.

Inputs:

```sh
kind create cluster --name provider-talos-issue-15
kubectl --context kind-provider-talos-issue-15 apply -R -f package/crds
KUBECONFIG=/tmp/provider-talos-issue-15.kubeconfig go run cmd/provider/main.go --debug --poll=5s
```

Applied resources:

```yaml
apiVersion: talos.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: None
---
apiVersion: machine.talos.crossplane.io/v1alpha1
kind: Secrets
metadata:
  name: issue-15-machine-secrets
spec:
  forProvider: {}
  providerConfigRef:
    name: default
  writeConnectionSecretToRef:
    name: issue-15-machine-secrets
    namespace: default
---
apiVersion: machine.talos.crossplane.io/v1alpha1
kind: Configuration
metadata:
  name: issue-15-worker-config
spec:
  forProvider:
    node: 10.0.0.2
    clusterName: issue-15-cluster
    machineType: worker
    clusterEndpoint: https://10.0.0.1:6443
    machineSecretsRef:
      name: issue-15-machine-secrets
    kubernetesVersion: v1.32.1
    configPatches:
      - |
        machine:
          nodeLabels:
            environment: kind-smoke
  providerConfigRef:
    name: default
  writeConnectionSecretToRef:
    name: issue-15-worker-config
    namespace: default
```

Observed controller logs:

```text
Observing Secrets: issue-15-machine-secrets
Successfully generated secrets (length: 109 bytes)
Observing Configuration: issue-15-worker-config
Configuration generated successfully (length: 2711)
```

Verification output:

```text
secrets.machine.talos.crossplane.io/issue-15-machine-secrets condition met
configuration.machine.talos.crossplane.io/issue-15-worker-config condition met
Ready: True
machineConfigurationHash: 654f175599d3ee609fea973ba874a6c3ec487b8a2bc472a8147880dade226add
generatedTime: 2026-05-11T16:47:54Z
decoded machine_configuration size: 2711 bytes
decoded machine_secrets size: 8819 bytes
hashes match: 654f175599d3ee609fea973ba874a6c3ec487b8a2bc472a8147880dade226add
status matches secret: 654f175599d3ee609fea973ba874a6c3ec487b8a2bc472a8147880dade226add
```

Decoded `machine_configuration` contained the expected generated and patched values:

```text
type: worker
environment: kind-smoke
endpoint: https://10.0.0.1:6443
clusterName: issue-15-cluster
```

[contribution process]: https://git.io/fj2m9