### PR TITLE
fix(bootstrap): trust configured Talos CA

### DIFF
--- a/internal/controller/bootstrap/bootstrap.go
+++ b/internal/controller/bootstrap/bootstrap.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -269,17 +270,9 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 		)
 	} else {
 		fmt.Printf("Using secure connection to %s\n", endpoint)
-		// Create a certificate from the provided certificates
-		cert, certErr := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
-		if certErr != nil {
-			return errors.Wrap(certErr, "failed to create client certificate")
-		}
-
-		// Create TLS config
-		tlsConfig := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			ServerName:   cr.Spec.ForProvider.Node, // Use node IP as server name
-			MinVersion:   tls.VersionTLS12,
+		tlsConfig, configErr := buildBootstrapTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
+		if configErr != nil {
+			return configErr
 		}
 
 		// Create Talos client
@@ -304,4 +297,27 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 
 	fmt.Printf("Successfully bootstrapped Talos cluster on endpoint %s\n", endpoint)
 	return nil
+}
+
+func buildBootstrapTLSConfig(clientConfig v1alpha1.ClientConfiguration, node string) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client certificate")
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ServerName:   node,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if clientConfig.CACertificate != "" && clientConfig.CACertificate != "insecure" {
+		roots := x509.NewCertPool()
+		if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
+			return nil, errors.New("failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = roots
+	}
+
+	return tlsConfig, nil
 }

--- a/internal/controller/bootstrap/bootstrap_test.go
+++ b/internal/controller/bootstrap/bootstrap_test.go
@@ -18,10 +18,20 @@ package bootstrap
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
@@ -71,4 +81,135 @@ func TestObserve(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildBootstrapTLSConfig(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCertificates(t)
+
+	tests := map[string]struct {
+		clientConfig v1alpha1.ClientConfiguration
+		node         string
+		check        func(t *testing.T, cfg *tls.Config)
+		wantErr      string
+	}{
+		"SecureWithCA": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			node: "127.0.0.1",
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				if len(cfg.Certificates) != 1 {
+					t.Fatalf("buildBootstrapTLSConfig(...): got %d certificates, want 1", len(cfg.Certificates))
+				}
+				if cfg.RootCAs == nil {
+					t.Fatal("buildBootstrapTLSConfig(...): RootCAs = nil")
+				}
+				if diff := cmp.Diff("127.0.0.1", cfg.ServerName); diff != "" {
+					t.Errorf("buildBootstrapTLSConfig(...).ServerName: -want, +got:\n%s", diff)
+				}
+				if diff := cmp.Diff(uint16(tls.VersionTLS12), cfg.MinVersion); diff != "" {
+					t.Errorf("buildBootstrapTLSConfig(...).MinVersion: -want, +got:\n%s", diff)
+				}
+			},
+		},
+		"InsecureCACertificateSkipsRootCAs": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     "insecure",
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			check: func(t *testing.T, cfg *tls.Config) {
+				t.Helper()
+				if cfg.RootCAs != nil {
+					t.Fatal("buildBootstrapTLSConfig(...): RootCAs != nil")
+				}
+			},
+		},
+		"InvalidCAErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     "invalid",
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: "failed to parse CA certificate",
+		},
+		"InvalidClientCertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: "invalid",
+				ClientKey:         clientKey,
+			},
+			wantErr: "failed to create client certificate",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildBootstrapTLSConfig(tc.clientConfig, tc.node)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("buildBootstrapTLSConfig(...): expected error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("buildBootstrapTLSConfig(...): got error %q, want to contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildBootstrapTLSConfig(...): unexpected error: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t, got)
+			}
+		})
+	}
+}
+
+func generateTestCertificates(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+
+	return string(caPEM), string(clientCertPEM), string(clientKeyPEM)
 }


### PR DESCRIPTION
### Description of your changes

Fixes #21

Bootstrap now uses the Talos API CA provided in `spec.forProvider.clientConfiguration.caCertificate` when constructing the secure TLS client configuration. The secure path builds a client certificate from `clientCertificate` and `clientKey`, sets the target node as `ServerName`, enforces TLS 1.2 or newer, and loads the supplied CA PEM into `RootCAs` so Talos API certificates signed by the generated Talos OS CA can be verified.

The CA loading is isolated in a small TLS configuration helper so it can be unit tested without creating a Talos client or performing a network bootstrap. Invalid CA PEM now returns `failed to parse CA certificate`, while the existing insecure maintenance-mode behavior remains unchanged.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Added focused unit tests for bootstrap TLS configuration covering valid CA loading, invalid CA input, the `insecure` CA sentinel, and invalid client certificate/key handling.

Tested with:

```sh
go test ./internal/controller/bootstrap ./internal/controller/configurationapply
go test ./...
```

[contribution process]: https://git.io/fj2m9