### PR TITLE
fix(bootstrap): observe already bootstrapped nodes

### DIFF
--- a/internal/controller/bootstrap/bootstrap.go
+++ b/internal/controller/bootstrap/bootstrap.go
@@ -21,9 +21,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"strings"
+	"time"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
 
@@ -36,6 +41,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -53,6 +59,8 @@ const (
 	errGetCreds     = "cannot get credentials"
 
 	errNewClient = "cannot create new Service"
+
+	certInsecure = "insecure"
 )
 
 // A NoOpService does nothing.
@@ -158,6 +166,10 @@ type external struct {
 	// A 'client' used to connect to the external resource API. In practice this
 	// would be something like an AWS SDK client.
 	service interface{}
+	// bootstrapFn allows tests to stub the non-idempotent Talos bootstrap call.
+	bootstrapFn func(context.Context, *v1alpha1.Bootstrap) error
+	// isBootstrappedHealthyFn allows tests to stub already-bootstrapped detection.
+	isBootstrappedHealthyFn func(context.Context, *v1alpha1.Bootstrap) bool
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -168,21 +180,21 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	fmt.Printf("Observing Bootstrap: %s\n", cr.Name)
 
-	// Check if cluster has been bootstrapped
-	clusterBootstrapped := cr.Status.AtProvider.Bootstrapped
-	bootstrapTimeExists := cr.Status.AtProvider.BootstrapTime != nil
+	bootstrapped := resolveBootstrappedStatus(cr)
+	if bootstrapped {
+		cr.SetConditions(xpv1.Available())
+	}
 
-	// Resource exists if we have bootstrapped the cluster
-	resourceExists := clusterBootstrapped && bootstrapTimeExists
+	if !bootstrapped && c.isBootstrappedHealthy(ctx, cr) {
+		markBootstrapped(cr, metav1.Now())
+		bootstrapped = true
+	}
 
-	// Resource is up to date if it exists
-	resourceUpToDate := resourceExists
-
-	fmt.Printf("Bootstrap exists: %v, up to date: %v\n", resourceExists, resourceUpToDate)
+	fmt.Printf("Bootstrap exists: %v, up to date: %v\n", bootstrapped, bootstrapped)
 
 	return managed.ExternalObservation{
-		ResourceExists:    resourceExists,
-		ResourceUpToDate:  resourceUpToDate,
+		ResourceExists:    bootstrapped,
+		ResourceUpToDate:  bootstrapped,
 		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
 }
@@ -196,15 +208,22 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	fmt.Printf("Bootstrapping Talos cluster on node: %s\n", cr.Spec.ForProvider.Node)
 
 	// Bootstrap the Talos cluster
-	err := c.bootstrapTalosCluster(ctx, cr)
+	err := c.bootstrap(ctx, cr)
 	if err != nil {
+		if isBootstrapAlreadyExists(err) && c.isBootstrappedHealthy(ctx, cr) {
+			markBootstrapped(cr, metav1.Now())
+			return managed.ExternalCreation{
+				ConnectionDetails: managed.ConnectionDetails{},
+			}, nil
+		}
+		if isBootstrapAlreadyExists(err) {
+			return managed.ExternalCreation{}, errors.Wrap(err, "bootstrap already exists but node health could not be verified")
+		}
+
 		return managed.ExternalCreation{}, errors.Wrap(err, "failed to bootstrap Talos cluster")
 	}
 
-	// Update status
-	cr.Status.AtProvider.Bootstrapped = true
-	now := metav1.Now()
-	cr.Status.AtProvider.BootstrapTime = &now
+	markBootstrapped(cr, metav1.Now())
 
 	return managed.ExternalCreation{
 		ConnectionDetails: managed.ConnectionDetails{},
@@ -241,6 +260,97 @@ func (c *external) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+func (c *external) bootstrap(ctx context.Context, cr *v1alpha1.Bootstrap) error {
+	if c.bootstrapFn != nil {
+		return c.bootstrapFn(ctx, cr)
+	}
+
+	return c.bootstrapTalosCluster(ctx, cr)
+}
+
+func resolveBootstrappedStatus(cr *v1alpha1.Bootstrap) bool {
+	bootstrapped := cr.Status.AtProvider.Bootstrapped || hasSuccessfulExternalCreate(cr)
+	if !bootstrapped {
+		return false
+	}
+
+	if cr.Status.AtProvider.BootstrapTime == nil {
+		if t := meta.GetExternalCreateSucceeded(cr); !t.IsZero() {
+			bootstrapTime := metav1.NewTime(t)
+			cr.Status.AtProvider.BootstrapTime = &bootstrapTime
+		}
+	}
+	if cr.Status.AtProvider.BootstrapTime == nil {
+		now := metav1.Now()
+		cr.Status.AtProvider.BootstrapTime = &now
+	}
+	cr.Status.AtProvider.Bootstrapped = true
+
+	return true
+}
+
+func hasSuccessfulExternalCreate(cr *v1alpha1.Bootstrap) bool {
+	return cr.GetAnnotations()[meta.AnnotationKeyExternalCreateSucceeded] != ""
+}
+
+func markBootstrapped(cr *v1alpha1.Bootstrap, when metav1.Time) {
+	cr.Status.AtProvider.Bootstrapped = true
+	cr.Status.AtProvider.BootstrapTime = &when
+	cr.SetConditions(xpv1.Available())
+}
+
+func isBootstrapAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	if status.Code(errors.Cause(err)) == codes.AlreadyExists || status.Code(err) == codes.AlreadyExists {
+		return true
+	}
+
+	errText := err.Error()
+	return strings.Contains(errText, "AlreadyExists") || strings.Contains(errText, "etcd data directory is not empty")
+}
+
+func (c *external) isBootstrappedHealthy(ctx context.Context, cr *v1alpha1.Bootstrap) bool {
+	if c.isBootstrappedHealthyFn != nil {
+		return c.isBootstrappedHealthyFn(ctx, cr)
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	clientConfig := cr.Spec.ForProvider.ClientConfiguration
+	if clientConfig.ClientCertificate == "" {
+		return false
+	}
+
+	endpoint := getBootstrapEndpoint(cr)
+	var tlsConfig *tls.Config
+	if clientConfig.ClientCertificate == certInsecure || clientConfig.CACertificate == certInsecure {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance-mode machines.
+		}
+	} else {
+		var err error
+		tlsConfig, err = buildBootstrapTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
+		if err != nil {
+			return false
+		}
+	}
+
+	talosClient, err := talosclient.New(checkCtx,
+		talosclient.WithTLSConfig(tlsConfig),
+		talosclient.WithEndpoints(endpoint),
+	)
+	if err != nil {
+		return false
+	}
+	defer talosClient.Close() //nolint:errcheck
+
+	_, err = talosClient.Version(checkCtx)
+	return err == nil
+}
+
 // bootstrapTalosCluster bootstraps the Talos cluster on the specified control plane node
 func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Bootstrap) error {
 	// Get client configuration
@@ -249,17 +359,13 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 		return errors.New("clientConfiguration is required")
 	}
 
-	// Determine endpoint - use provided endpoint or default to node:50000
-	endpoint := cr.Spec.ForProvider.Node + ":50000"
-	if cr.Spec.ForProvider.Endpoint != nil && *cr.Spec.ForProvider.Endpoint != "" {
-		endpoint = *cr.Spec.ForProvider.Endpoint
-	}
+	endpoint := getBootstrapEndpoint(cr)
 
 	// Handle insecure mode (when certificates are "insecure")
 	var talosClient *talosclient.Client
 	var err error
 
-	if clientConfig.ClientCertificate == "insecure" || clientConfig.CACertificate == "insecure" {
+	if clientConfig.ClientCertificate == certInsecure || clientConfig.CACertificate == certInsecure {
 		fmt.Printf("Using insecure connection to %s\n", endpoint)
 		// Create insecure client
 		talosClient, err = talosclient.New(ctx,
@@ -299,6 +405,15 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 	return nil
 }
 
+func getBootstrapEndpoint(cr *v1alpha1.Bootstrap) string {
+	endpoint := cr.Spec.ForProvider.Node + ":50000"
+	if cr.Spec.ForProvider.Endpoint != nil && *cr.Spec.ForProvider.Endpoint != "" {
+		endpoint = *cr.Spec.ForProvider.Endpoint
+	}
+
+	return endpoint
+}
+
 func buildBootstrapTLSConfig(clientConfig v1alpha1.ClientConfiguration, node string) (*tls.Config, error) {
 	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
 	if err != nil {
@@ -311,7 +426,7 @@ func buildBootstrapTLSConfig(clientConfig v1alpha1.ClientConfiguration, node str
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	if clientConfig.CACertificate != "" && clientConfig.CACertificate != "insecure" {
+	if clientConfig.CACertificate != "" && clientConfig.CACertificate != certInsecure {
 		roots := x509.NewCertPool()
 		if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
 			return nil, errors.New("failed to parse CA certificate")

--- a/internal/controller/bootstrap/bootstrap_test.go
+++ b/internal/controller/bootstrap/bootstrap_test.go
@@ -29,7 +29,14 @@ import (
 	"testing"
 	"time"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane-contrib/provider-talos/apis/machine/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -78,6 +85,171 @@ func TestObserve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.o, got); diff != "" {
 				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestObserveWithSuccessfulExternalCreate(t *testing.T) {
+	createdAt := time.Date(2026, 5, 13, 20, 29, 41, 0, time.UTC)
+	cr := testBootstrap()
+	meta.SetExternalCreateSucceeded(cr, createdAt)
+
+	e := external{isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return false }}
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if !got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = false, want true")
+	}
+	if !got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = false, want true")
+	}
+	if !cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = false, want true")
+	}
+	if cr.Status.AtProvider.BootstrapTime == nil || !cr.Status.AtProvider.BootstrapTime.Time.Equal(createdAt) {
+		t.Fatalf("cr.Status.AtProvider.BootstrapTime = %v, want %v", cr.Status.AtProvider.BootstrapTime, createdAt)
+	}
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got != corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want %s", got, corev1.ConditionTrue)
+	}
+}
+
+func TestObserveAlreadyHealthyWithoutStatus(t *testing.T) {
+	cr := testBootstrap()
+	e := external{isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return true }}
+
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if !got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = false, want true")
+	}
+	if !got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = false, want true")
+	}
+	if !cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = false, want true")
+	}
+	if cr.Status.AtProvider.BootstrapTime == nil {
+		t.Fatal("cr.Status.AtProvider.BootstrapTime = nil, want timestamp")
+	}
+}
+
+func TestObserveMissingAndUnhealthy(t *testing.T) {
+	cr := testBootstrap()
+	e := external{isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return false }}
+
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = true, want false")
+	}
+	if got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = true, want false")
+	}
+	if cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = true, want false")
+	}
+}
+
+func TestCreateAlreadyExistsHealthyIsSuccess(t *testing.T) {
+	cr := testBootstrap()
+	e := external{
+		bootstrapFn: func(context.Context, *v1alpha1.Bootstrap) error {
+			return status.Error(codes.AlreadyExists, "etcd data directory is not empty")
+		},
+		isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return true },
+	}
+
+	_, err := e.Create(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Create(...): unexpected error: %v", err)
+	}
+	if !cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = false, want true")
+	}
+	if cr.Status.AtProvider.BootstrapTime == nil {
+		t.Fatal("cr.Status.AtProvider.BootstrapTime = nil, want timestamp")
+	}
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got != corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want %s", got, corev1.ConditionTrue)
+	}
+}
+
+func TestCreateAlreadyExistsUnhealthyReturnsError(t *testing.T) {
+	cr := testBootstrap()
+	e := external{
+		bootstrapFn: func(context.Context, *v1alpha1.Bootstrap) error {
+			return status.Error(codes.AlreadyExists, "etcd data directory is not empty")
+		},
+		isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return false },
+	}
+
+	_, err := e.Create(context.Background(), cr)
+	if err == nil {
+		t.Fatal("e.Create(...): expected error")
+	}
+	if !strings.Contains(err.Error(), "health could not be verified") {
+		t.Fatalf("e.Create(...): got error %q, want health verification context", err.Error())
+	}
+}
+
+func TestCreateNonAlreadyExistsReturnsError(t *testing.T) {
+	cr := testBootstrap()
+	e := external{
+		bootstrapFn:             func(context.Context, *v1alpha1.Bootstrap) error { return errors.New("permission denied") },
+		isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return true },
+	}
+
+	_, err := e.Create(context.Background(), cr)
+	if err == nil {
+		t.Fatal("e.Create(...): expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to bootstrap Talos cluster") {
+		t.Fatalf("e.Create(...): got error %q, want bootstrap failure context", err.Error())
+	}
+}
+
+func TestIsBootstrapAlreadyExists(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"Nil": {
+			want: false,
+		},
+		"GRPCAlreadyExists": {
+			err:  status.Error(codes.AlreadyExists, "etcd data directory is not empty"),
+			want: true,
+		},
+		"WrappedGRPCAlreadyExists": {
+			err:  errors.Wrap(status.Error(codes.AlreadyExists, "etcd data directory is not empty"), "failed to bootstrap Talos cluster"),
+			want: true,
+		},
+		"KnownMessage": {
+			err:  errors.New("rpc error: code = AlreadyExists desc = etcd data directory is not empty"),
+			want: true,
+		},
+		"Unrelated": {
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isBootstrapAlreadyExists(tc.err)
+			if got != tc.want {
+				t.Fatalf("isBootstrapAlreadyExists(...): got %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -165,6 +337,18 @@ func TestBuildBootstrapTLSConfig(t *testing.T) {
 				tc.check(t, got)
 			}
 		})
+	}
+}
+
+func testBootstrap() *v1alpha1.Bootstrap {
+	return &v1alpha1.Bootstrap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bootstrap"},
+		Spec: v1alpha1.BootstrapSpec{ForProvider: v1alpha1.BootstrapParameters{
+			Node: "127.0.0.1",
+			ClientConfiguration: v1alpha1.ClientConfiguration{
+				ClientCertificate: "insecure",
+			},
+		}},
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Make `Bootstrap` converge when Talos has already successfully bootstrapped the node.

`Bootstrap` now observes prior successful create annotations and verified already-configured Talos nodes as existing external state. It also treats Talos `AlreadyExists` bootstrap responses, including `etcd data directory is not empty`, as idempotent success when the node can be verified as reachable/configured.

Fixes #23

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Unit tests:

```sh
go test ./internal/controller/bootstrap
go test ./...
git diff --check
```

Local smoke test with Docker, kind, kubectl, and the provider run externally via `go run`:

```sh
kind create cluster --name provider-talos-smoke
kubectl --context kind-provider-talos-smoke apply -R -f package/crds
KUBECONFIG=/tmp/provider-talos-smoke.kubeconfig go run cmd/provider/main.go --debug --poll=5s
```

Applied smoke resources:

- `ProviderConfig/default` with `credentials.source: None`
- `Secrets/smoke-machine-secrets`
- `Configuration/smoke-worker-config` with worker machine config and `environment: kind-smoke` patch

Ready checks:

```text
secrets.machine.talos.crossplane.io/smoke-machine-secrets condition met
configuration.machine.talos.crossplane.io/smoke-worker-config condition met
```

Decoded connection secret sizes:

```text
    2708 /tmp/smoke-machine-config.yaml
    8807 /tmp/smoke-machine-secrets.json
   11515 total
```

Generated config content check:

```text
    type: worker
        environment: kind-smoke
        endpoint: https://10.0.0.1:6443
    clusterName: smoke-cluster
```

Connection secret/status hash verification:

```text
hashes match: 088da512f830d61ba73d51f7fe57e30b2824668b53c493860cda8e091f8297cd
status matches secret: 088da512f830d61ba73d51f7fe57e30b2824668b53c493860cda8e091f8297cd
True
088da512f830d61ba73d51f7fe57e30b2824668b53c493860cda8e091f8297cd
2026-05-13T21:36:28Z
```

Provider log evidence:

```text
DEBUG provider-talos Reconciling {"controller": "managed/secrets.machine.talos.crossplane.io", "request": {"name":"smoke-machine-secrets"}}
DEBUG provider-talos External resource is up to date {"controller": "managed/secrets.machine.talos.crossplane.io", "request": {"name":"smoke-machine-secrets"}}
DEBUG provider-talos Reconciling {"controller": "managed/configuration.machine.talos.crossplane.io", "request": {"name":"smoke-worker-config"}}
DEBUG provider-talos External resource is up to date {"controller": "managed/configuration.machine.talos.crossplane.io", "request": {"name":"smoke-worker-config"}}
```

[contribution process]: https://git.io/fj2m9