### PR TITLE
fix(bootstrap): use Talos client config

### DIFF
--- a/internal/controller/bootstrap/bootstrap.go
+++ b/internal/controller/bootstrap/bootstrap.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	siderox509 "github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -325,29 +327,32 @@ func (c *external) isBootstrappedHealthy(ctx context.Context, cr *v1alpha1.Boots
 	}
 
 	endpoint := getBootstrapEndpoint(cr)
-	var tlsConfig *tls.Config
+	var talosClient *talosclient.Client
+	var err error
 	if clientConfig.ClientCertificate == certInsecure || clientConfig.CACertificate == certInsecure {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance-mode machines.
-		}
+		talosClient, err = talosclient.New(checkCtx,
+			talosclient.WithTLSConfig(&tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance-mode machines.
+			}),
+			talosclient.WithEndpoints(endpoint),
+		)
 	} else {
-		var err error
-		tlsConfig, err = buildBootstrapTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
-		if err != nil {
+		talosConfig, configErr := buildBootstrapClientConfig(clientConfig)
+		if configErr != nil {
 			return false
 		}
-	}
 
-	talosClient, err := talosclient.New(checkCtx,
-		talosclient.WithTLSConfig(tlsConfig),
-		talosclient.WithEndpoints(endpoint),
-	)
+		talosClient, err = talosclient.New(checkCtx,
+			talosclient.WithConfig(talosConfig),
+			talosclient.WithEndpoints(endpoint),
+		)
+	}
 	if err != nil {
 		return false
 	}
 	defer talosClient.Close() //nolint:errcheck
 
-	_, err = talosClient.Version(checkCtx)
+	_, err = talosClient.Version(talosclient.WithNode(checkCtx, cr.Spec.ForProvider.Node))
 	return err == nil
 }
 
@@ -376,14 +381,14 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 		)
 	} else {
 		fmt.Printf("Using secure connection to %s\n", endpoint)
-		tlsConfig, configErr := buildBootstrapTLSConfig(clientConfig, cr.Spec.ForProvider.Node)
+		talosConfig, configErr := buildBootstrapClientConfig(clientConfig)
 		if configErr != nil {
 			return configErr
 		}
 
 		// Create Talos client
 		talosClient, err = talosclient.New(ctx,
-			talosclient.WithTLSConfig(tlsConfig),
+			talosclient.WithConfig(talosConfig),
 			talosclient.WithEndpoints(endpoint),
 		)
 	}
@@ -396,7 +401,7 @@ func (c *external) bootstrapTalosCluster(ctx context.Context, cr *v1alpha1.Boots
 	fmt.Printf("Attempting to bootstrap Talos cluster on endpoint %s\n", endpoint)
 
 	// Bootstrap the cluster
-	err = talosClient.Bootstrap(ctx, &machine.BootstrapRequest{})
+	err = talosClient.Bootstrap(talosclient.WithNode(ctx, cr.Spec.ForProvider.Node), &machine.BootstrapRequest{})
 	if err != nil {
 		return errors.Wrap(err, "failed to bootstrap Talos cluster")
 	}
@@ -414,25 +419,32 @@ func getBootstrapEndpoint(cr *v1alpha1.Bootstrap) string {
 	return endpoint
 }
 
-func buildBootstrapTLSConfig(clientConfig v1alpha1.ClientConfiguration, node string) (*tls.Config, error) {
+func buildBootstrapClientConfig(clientConfig v1alpha1.ClientConfiguration) (*clientconfig.Config, error) {
+	if clientConfig.ClientCertificate == "" {
+		return nil, errors.New("clientConfiguration.clientCertificate is required")
+	}
+	if clientConfig.ClientKey == "" {
+		return nil, errors.New("clientConfiguration.clientKey is required")
+	}
+	if clientConfig.CACertificate == "" {
+		return nil, errors.New("clientConfiguration.caCertificate is required")
+	}
+
 	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create client certificate")
 	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ServerName:   node,
-		MinVersion:   tls.VersionTLS12,
+	if len(cert.Certificate) == 0 {
+		return nil, errors.New("failed to create client certificate")
 	}
 
-	if clientConfig.CACertificate != "" && clientConfig.CACertificate != certInsecure {
-		roots := x509.NewCertPool()
-		if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
-			return nil, errors.New("failed to parse CA certificate")
-		}
-		tlsConfig.RootCAs = roots
+	roots := x509.NewCertPool()
+	if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
+		return nil, errors.New("failed to parse CA certificate")
 	}
 
-	return tlsConfig, nil
+	return clientconfig.NewConfig("dynamic", nil, []byte(clientConfig.CACertificate), &siderox509.PEMEncodedCertificateAndKey{
+		Crt: []byte(clientConfig.ClientCertificate),
+		Key: []byte(clientConfig.ClientKey),
+	}), nil
 }

--- a/internal/controller/bootstrap/bootstrap_test.go
+++ b/internal/controller/bootstrap/bootstrap_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 	"strings"
@@ -255,49 +255,18 @@ func TestIsBootstrapAlreadyExists(t *testing.T) {
 	}
 }
 
-func TestBuildBootstrapTLSConfig(t *testing.T) {
+func TestBuildBootstrapClientConfig(t *testing.T) {
 	caCert, clientCert, clientKey := generateTestCertificates(t)
 
 	tests := map[string]struct {
 		clientConfig v1alpha1.ClientConfiguration
-		node         string
-		check        func(t *testing.T, cfg *tls.Config)
 		wantErr      string
 	}{
-		"SecureWithCA": {
+		"SecureWithPEMValues": {
 			clientConfig: v1alpha1.ClientConfiguration{
 				CACertificate:     caCert,
 				ClientCertificate: clientCert,
 				ClientKey:         clientKey,
-			},
-			node: "127.0.0.1",
-			check: func(t *testing.T, cfg *tls.Config) {
-				t.Helper()
-				if len(cfg.Certificates) != 1 {
-					t.Fatalf("buildBootstrapTLSConfig(...): got %d certificates, want 1", len(cfg.Certificates))
-				}
-				if cfg.RootCAs == nil {
-					t.Fatal("buildBootstrapTLSConfig(...): RootCAs = nil")
-				}
-				if diff := cmp.Diff("127.0.0.1", cfg.ServerName); diff != "" {
-					t.Errorf("buildBootstrapTLSConfig(...).ServerName: -want, +got:\n%s", diff)
-				}
-				if diff := cmp.Diff(uint16(tls.VersionTLS12), cfg.MinVersion); diff != "" {
-					t.Errorf("buildBootstrapTLSConfig(...).MinVersion: -want, +got:\n%s", diff)
-				}
-			},
-		},
-		"InsecureCACertificateSkipsRootCAs": {
-			clientConfig: v1alpha1.ClientConfiguration{
-				CACertificate:     "insecure",
-				ClientCertificate: clientCert,
-				ClientKey:         clientKey,
-			},
-			check: func(t *testing.T, cfg *tls.Config) {
-				t.Helper()
-				if cfg.RootCAs != nil {
-					t.Fatal("buildBootstrapTLSConfig(...): RootCAs != nil")
-				}
 			},
 		},
 		"InvalidCAErrors": {
@@ -316,27 +285,73 @@ func TestBuildBootstrapTLSConfig(t *testing.T) {
 			},
 			wantErr: "failed to create client certificate",
 		},
+		"MissingCACertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: "clientConfiguration.caCertificate is required",
+		},
+		"MissingClientCertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate: caCert,
+				ClientKey:     clientKey,
+			},
+			wantErr: "clientConfiguration.clientCertificate is required",
+		},
+		"MissingClientKeyErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+			},
+			wantErr: "clientConfiguration.clientKey is required",
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := buildBootstrapTLSConfig(tc.clientConfig, tc.node)
+			got, err := buildBootstrapClientConfig(tc.clientConfig)
 			if tc.wantErr != "" {
 				if err == nil {
-					t.Fatal("buildBootstrapTLSConfig(...): expected error")
+					t.Fatal("buildBootstrapClientConfig(...): expected error")
 				}
 				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("buildBootstrapTLSConfig(...): got error %q, want to contain %q", err.Error(), tc.wantErr)
+					t.Fatalf("buildBootstrapClientConfig(...): got error %q, want to contain %q", err.Error(), tc.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("buildBootstrapTLSConfig(...): unexpected error: %v", err)
+				t.Fatalf("buildBootstrapClientConfig(...): unexpected error: %v", err)
 			}
-			if tc.check != nil {
-				tc.check(t, got)
+			if diff := cmp.Diff("dynamic", got.Context); diff != "" {
+				t.Errorf("buildBootstrapClientConfig(...).Context: -want, +got:\n%s", diff)
+			}
+			if len(got.Contexts) != 1 {
+				t.Fatalf("buildBootstrapClientConfig(...): got %d contexts, want 1", len(got.Contexts))
+			}
+			ctx := got.Contexts["dynamic"]
+			if ctx == nil {
+				t.Fatal("buildBootstrapClientConfig(...).Contexts[dynamic] = nil")
+			}
+			assertBase64Value(t, "CA", ctx.CA, tc.clientConfig.CACertificate)
+			assertBase64Value(t, "Crt", ctx.Crt, tc.clientConfig.ClientCertificate)
+			assertBase64Value(t, "Key", ctx.Key, tc.clientConfig.ClientKey)
+			if len(ctx.Endpoints) != 0 {
+				t.Fatalf("buildBootstrapClientConfig(...).Contexts[dynamic].Endpoints = %v, want empty", ctx.Endpoints)
 			}
 		})
+	}
+}
+
+func assertBase64Value(t *testing.T, field, got, wantDecoded string) {
+	t.Helper()
+
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	if err != nil {
+		t.Fatalf("%s is not base64 encoded: %v", field, err)
+	}
+	if diff := cmp.Diff(wantDecoded, string(decoded)); diff != "" {
+		t.Fatalf("%s decoded value: -want, +got:\n%s", field, diff)
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

fixes https://github.com/crossplane-contrib/provider-talos/issues/25

Bootstrap secure mode now builds a Talos SDK client configuration from the existing PEM-based `clientConfiguration` fields instead of constructing a manual `tls.Config`. This keeps Bootstrap aligned with the Talos SDK and `talosctl` credential path, while preserving the existing insecure sentinel behavior for maintenance-mode/test usage.

This also passes `spec.forProvider.node` through request context with `talosclient.WithNode` for both the Bootstrap call and the observe-time `Version` health probe.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Recreation steps: TBD

Unit and package tests:

```console
$ go test ./internal/controller/bootstrap
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/bootstrap	0.647s

$ go test ./internal/controller/configurationapply ./internal/controller/secrets
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/configurationapply	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/secrets	(cached)

$ go test ./...
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/bootstrap	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/configuration	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/configurationapply	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/factoryschematic	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/kubeconfig	(cached)
ok  	github.com/crossplane-contrib/provider-talos/internal/controller/secrets	(cached)
```

The Bootstrap unit tests accurately cover the behavior that can be validated locally without a live Talos API endpoint:

- Plain PEM `clientConfiguration` CA, client certificate, and client key are accepted.
- The helper returns a Talos SDK client config with a single `dynamic` context.
- The returned SDK context stores CA, client certificate, and client key as base64-encoded values that decode back to the original PEM bytes.
- Invalid CA PEM fails with `failed to parse CA certificate`.
- Invalid client certificate/key input fails with `failed to create client certificate`.
- Missing secure-mode fields fail with explicit validation errors.

The package tests also compile and exercise the updated Bootstrap code path that now constructs secure clients with `talosclient.WithConfig` and passes `spec.forProvider.node` with `talosclient.WithNode` for Bootstrap and health probes.

End-to-end validation against a real Talos API endpoint with distinct endpoint and node values is still pending.

[contribution process]: https://git.io/fj2m9
