### PR TITLE
Fix kubeconfig retrieval and observation

### DIFF
--- a/internal/controller/kubeconfig/kubeconfig.go
+++ b/internal/controller/kubeconfig/kubeconfig.go
@@ -19,9 +19,12 @@ package kubeconfig
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 
+	siderox509 "github.com/siderolabs/crypto/x509"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
@@ -302,28 +305,17 @@ func (c *external) retrieveKubeconfig(ctx context.Context, cr *v1alpha1.Kubeconf
 func retrieveKubeconfigFromTalos(ctx context.Context, cr *v1alpha1.Kubeconfig) (string, error) {
 	// Get client configuration
 	clientConfig := cr.Spec.ForProvider.ClientConfiguration
-	if clientConfig.ClientCertificate == "" {
-		return "", errors.New("clientConfiguration is required")
-	}
-
-	// Create a certificate from the provided certificates
-	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
+	talosConfig, err := buildKubeconfigClientConfig(clientConfig)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create client certificate")
+		return "", err
 	}
 
-	// Create TLS config
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ServerName:   cr.Spec.ForProvider.Node, // Use node IP as server name
-		MinVersion:   tls.VersionTLS12,
-	}
+	endpoint := getKubeconfigEndpoint(cr)
 
 	// Create Talos client
-	endpoints := []string{cr.Spec.ForProvider.Node + ":50000"} // Default Talos port
 	talosClient, err := talosclient.New(ctx,
-		talosclient.WithTLSConfig(tlsConfig),
-		talosclient.WithEndpoints(endpoints...),
+		talosclient.WithConfig(talosConfig),
+		talosclient.WithEndpoints(endpoint),
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create Talos client")
@@ -331,7 +323,7 @@ func retrieveKubeconfigFromTalos(ctx context.Context, cr *v1alpha1.Kubeconfig) (
 	defer talosClient.Close() // nolint:errcheck
 
 	// Retrieve the kubeconfig
-	kubeconfigBytes, err := talosClient.Kubeconfig(ctx)
+	kubeconfigBytes, err := talosClient.Kubeconfig(talosclient.WithNode(ctx, cr.Spec.ForProvider.Node))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to retrieve kubeconfig from Talos node")
 	}
@@ -343,6 +335,45 @@ func retrieveKubeconfigFromTalos(ctx context.Context, cr *v1alpha1.Kubeconfig) (
 	fmt.Printf("Successfully retrieved kubeconfig from node %s\n", cr.Spec.ForProvider.Node)
 
 	return string(kubeconfigBytes), nil
+}
+
+func getKubeconfigEndpoint(cr *v1alpha1.Kubeconfig) string {
+	endpoint := cr.Spec.ForProvider.Node + ":50000"
+	if cr.Spec.ForProvider.Endpoint != nil && *cr.Spec.ForProvider.Endpoint != "" {
+		endpoint = *cr.Spec.ForProvider.Endpoint
+	}
+
+	return endpoint
+}
+
+func buildKubeconfigClientConfig(clientConfig v1alpha1.ClientConfiguration) (*clientconfig.Config, error) {
+	if clientConfig.ClientCertificate == "" {
+		return nil, errors.New("clientConfiguration.clientCertificate is required")
+	}
+	if clientConfig.ClientKey == "" {
+		return nil, errors.New("clientConfiguration.clientKey is required")
+	}
+	if clientConfig.CACertificate == "" {
+		return nil, errors.New("clientConfiguration.caCertificate is required")
+	}
+
+	cert, err := tls.X509KeyPair([]byte(clientConfig.ClientCertificate), []byte(clientConfig.ClientKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client certificate")
+	}
+	if len(cert.Certificate) == 0 {
+		return nil, errors.New("failed to create client certificate")
+	}
+
+	roots := x509.NewCertPool()
+	if ok := roots.AppendCertsFromPEM([]byte(clientConfig.CACertificate)); !ok {
+		return nil, errors.New("failed to parse CA certificate")
+	}
+
+	return clientconfig.NewConfig("dynamic", nil, []byte(clientConfig.CACertificate), &siderox509.PEMEncodedCertificateAndKey{
+		Crt: []byte(clientConfig.ClientCertificate),
+		Key: []byte(clientConfig.ClientKey),
+	}), nil
 }
 
 func parseKubeconfig(kubeconfigData string) (*v1alpha1.KubernetesClientConfiguration, error) {

--- a/internal/controller/kubeconfig/kubeconfig_test.go
+++ b/internal/controller/kubeconfig/kubeconfig_test.go
@@ -18,8 +18,16 @@ package kubeconfig
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -219,6 +227,134 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestGetKubeconfigEndpoint(t *testing.T) {
+	emptyEndpoint := ""
+	customEndpoint := "10.0.0.5:50000"
+
+	tests := map[string]struct {
+		cr   *v1alpha1.Kubeconfig
+		want string
+	}{
+		"Default": {
+			cr: &v1alpha1.Kubeconfig{Spec: v1alpha1.KubeconfigSpec{ForProvider: v1alpha1.KubeconfigParameters{
+				Node: "10.0.0.1",
+			}}},
+			want: "10.0.0.1:50000",
+		},
+		"EmptyEndpoint": {
+			cr: &v1alpha1.Kubeconfig{Spec: v1alpha1.KubeconfigSpec{ForProvider: v1alpha1.KubeconfigParameters{
+				Node:     "10.0.0.2",
+				Endpoint: &emptyEndpoint,
+			}}},
+			want: "10.0.0.2:50000",
+		},
+		"CustomEndpoint": {
+			cr: &v1alpha1.Kubeconfig{Spec: v1alpha1.KubeconfigSpec{ForProvider: v1alpha1.KubeconfigParameters{
+				Node:     "10.0.0.3",
+				Endpoint: &customEndpoint,
+			}}},
+			want: customEndpoint,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := getKubeconfigEndpoint(tc.cr)
+			if got != tc.want {
+				t.Fatalf("getKubeconfigEndpoint(...): got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildKubeconfigClientConfig(t *testing.T) {
+	caCert, clientCert, clientKey := generateTestCertificates(t)
+
+	tests := map[string]struct {
+		clientConfig v1alpha1.ClientConfiguration
+		wantErr      string
+	}{
+		"SecureWithPEMValues": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+		},
+		"InvalidCAErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     "invalid",
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: "failed to parse CA certificate",
+		},
+		"InvalidClientCertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: "invalid",
+				ClientKey:         clientKey,
+			},
+			wantErr: "failed to create client certificate",
+		},
+		"MissingCACertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				ClientCertificate: clientCert,
+				ClientKey:         clientKey,
+			},
+			wantErr: "clientConfiguration.caCertificate is required",
+		},
+		"MissingClientCertificateErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate: caCert,
+				ClientKey:     clientKey,
+			},
+			wantErr: "clientConfiguration.clientCertificate is required",
+		},
+		"MissingClientKeyErrors": {
+			clientConfig: v1alpha1.ClientConfiguration{
+				CACertificate:     caCert,
+				ClientCertificate: clientCert,
+			},
+			wantErr: "clientConfiguration.clientKey is required",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildKubeconfigClientConfig(tc.clientConfig)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatal("buildKubeconfigClientConfig(...): expected error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("buildKubeconfigClientConfig(...): got error %q, want to contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildKubeconfigClientConfig(...): unexpected error: %v", err)
+			}
+			if diff := cmp.Diff("dynamic", got.Context); diff != "" {
+				t.Errorf("buildKubeconfigClientConfig(...).Context: -want, +got:\n%s", diff)
+			}
+			if len(got.Contexts) != 1 {
+				t.Fatalf("buildKubeconfigClientConfig(...): got %d contexts, want 1", len(got.Contexts))
+			}
+			ctx := got.Contexts["dynamic"]
+			if ctx == nil {
+				t.Fatal("buildKubeconfigClientConfig(...).Contexts[dynamic] = nil")
+			}
+			assertBase64Value(t, "CA", ctx.CA, tc.clientConfig.CACertificate)
+			assertBase64Value(t, "Crt", ctx.Crt, tc.clientConfig.ClientCertificate)
+			assertBase64Value(t, "Key", ctx.Key, tc.clientConfig.ClientKey)
+			if len(ctx.Endpoints) != 0 {
+				t.Fatalf("buildKubeconfigClientConfig(...).Contexts[dynamic].Endpoints = %v, want empty", ctx.Endpoints)
+			}
+		})
+	}
+}
+
 func TestParseKubeconfig(t *testing.T) {
 	type want struct {
 		configuration *v1alpha1.KubernetesClientConfiguration
@@ -333,6 +469,65 @@ func testKubeClient(t *testing.T, objects ...runtime.Object) ctrlclient.Client {
 
 	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 }
+
+func assertBase64Value(t *testing.T, field, got, wantDecoded string) {
+	t.Helper()
+
+	decoded, err := base64.StdEncoding.DecodeString(got)
+	if err != nil {
+		t.Fatalf("%s is not base64 encoded: %v", field, err)
+	}
+	if diff := cmp.Diff(wantDecoded, string(decoded)); diff != "" {
+		t.Fatalf("%s decoded value: -want, +got:\n%s", field, diff)
+	}
+}
+
+func generateTestCertificates(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(...): %v", err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(...): %v", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+
+	return string(caPEM), string(clientCertPEM), string(clientKeyPEM)
+}
+
 func testClientConfiguration() *v1alpha1.KubernetesClientConfiguration {
 	return &v1alpha1.KubernetesClientConfiguration{
 		Host:              "https://127.0.0.1:6443",


### PR DESCRIPTION
## Summary
- Persist retrieved kubeconfig client configuration in status so observation can report existing resources.
- Build kubeconfig retrieval Talos clients from supplied CA/client cert/client key instead of a manual TLS config without RootCAs.
- Respect the configured Talos endpoint and scope kubeconfig retrieval to the requested node.

## Testing
- go test ./internal/controller/kubeconfig
- go test ./internal/controller/bootstrap ./internal/controller/configurationapply ./internal/controller/kubeconfig
- go test ./...

Fixes #29