### PR TITLE
fix(bootstrap): verify Talos etcd health before ready

### DIFF
--- a/internal/controller/bootstrap/bootstrap.go
+++ b/internal/controller/bootstrap/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -172,6 +173,13 @@ type external struct {
 	bootstrapFn func(context.Context, *v1alpha1.Bootstrap) error
 	// isBootstrappedHealthyFn allows tests to stub already-bootstrapped detection.
 	isBootstrappedHealthyFn func(context.Context, *v1alpha1.Bootstrap) bool
+	// newBootstrapHealthClientFn allows tests to stub Talos service state checks.
+	newBootstrapHealthClientFn func(context.Context, *v1alpha1.Bootstrap) (bootstrapHealthClient, error)
+}
+
+type bootstrapHealthClient interface {
+	ServiceInfo(context.Context, string, ...grpc.CallOption) ([]talosclient.ServiceInfo, error)
+	Close() error
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -182,20 +190,19 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	fmt.Printf("Observing Bootstrap: %s\n", cr.Name)
 
-	bootstrapped := resolveBootstrappedStatus(cr)
+	bootstrapped := c.isBootstrappedHealthy(ctx, cr)
 	if bootstrapped {
-		cr.SetConditions(xpv1.Available())
-	}
-
-	if !bootstrapped && c.isBootstrappedHealthy(ctx, cr) {
 		markBootstrapped(cr, metav1.Now())
-		bootstrapped = true
+	} else if hasSuccessfulExternalCreate(cr) || cr.Status.AtProvider.Bootstrapped {
+		cr.SetConditions(xpv1.Unavailable())
 	}
 
-	fmt.Printf("Bootstrap exists: %v, up to date: %v\n", bootstrapped, bootstrapped)
+	exists := bootstrapped || hasSuccessfulExternalCreate(cr) || cr.Status.AtProvider.Bootstrapped
+
+	fmt.Printf("Bootstrap exists: %v, up to date: %v\n", exists, bootstrapped)
 
 	return managed.ExternalObservation{
-		ResourceExists:    bootstrapped,
+		ResourceExists:    exists,
 		ResourceUpToDate:  bootstrapped,
 		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
@@ -219,13 +226,15 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 			}, nil
 		}
 		if isBootstrapAlreadyExists(err) {
-			return managed.ExternalCreation{}, errors.Wrap(err, "bootstrap already exists but node health could not be verified")
+			return managed.ExternalCreation{}, errors.Wrap(err, "bootstrap already exists but Talos-side bootstrap completion could not be verified")
 		}
 
 		return managed.ExternalCreation{}, errors.Wrap(err, "failed to bootstrap Talos cluster")
 	}
 
-	markBootstrapped(cr, metav1.Now())
+	if c.isBootstrappedHealthy(ctx, cr) {
+		markBootstrapped(cr, metav1.Now())
+	}
 
 	return managed.ExternalCreation{
 		ConnectionDetails: managed.ConnectionDetails{},
@@ -270,27 +279,6 @@ func (c *external) bootstrap(ctx context.Context, cr *v1alpha1.Bootstrap) error 
 	return c.bootstrapTalosCluster(ctx, cr)
 }
 
-func resolveBootstrappedStatus(cr *v1alpha1.Bootstrap) bool {
-	bootstrapped := cr.Status.AtProvider.Bootstrapped || hasSuccessfulExternalCreate(cr)
-	if !bootstrapped {
-		return false
-	}
-
-	if cr.Status.AtProvider.BootstrapTime == nil {
-		if t := meta.GetExternalCreateSucceeded(cr); !t.IsZero() {
-			bootstrapTime := metav1.NewTime(t)
-			cr.Status.AtProvider.BootstrapTime = &bootstrapTime
-		}
-	}
-	if cr.Status.AtProvider.BootstrapTime == nil {
-		now := metav1.Now()
-		cr.Status.AtProvider.BootstrapTime = &now
-	}
-	cr.Status.AtProvider.Bootstrapped = true
-
-	return true
-}
-
 func hasSuccessfulExternalCreate(cr *v1alpha1.Bootstrap) bool {
 	return cr.GetAnnotations()[meta.AnnotationKeyExternalCreateSucceeded] != ""
 }
@@ -321,16 +309,41 @@ func (c *external) isBootstrappedHealthy(ctx context.Context, cr *v1alpha1.Boots
 	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	talosClient, err := c.newBootstrapHealthClient(checkCtx, cr)
+	if err != nil {
+		return false
+	}
+	defer talosClient.Close() //nolint:errcheck
+
+	services, err := talosClient.ServiceInfo(talosclient.WithNode(checkCtx, cr.Spec.ForProvider.Node), "etcd")
+	if err != nil || len(services) == 0 {
+		return false
+	}
+
+	for _, service := range services {
+		if isHealthyEtcdService(service.Service) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *external) newBootstrapHealthClient(ctx context.Context, cr *v1alpha1.Bootstrap) (bootstrapHealthClient, error) {
+	if c.newBootstrapHealthClientFn != nil {
+		return c.newBootstrapHealthClientFn(ctx, cr)
+	}
+
 	clientConfig := cr.Spec.ForProvider.ClientConfiguration
 	if clientConfig.ClientCertificate == "" {
-		return false
+		return nil, errors.New("clientConfiguration is required")
 	}
 
 	endpoint := getBootstrapEndpoint(cr)
 	var talosClient *talosclient.Client
 	var err error
 	if clientConfig.ClientCertificate == certInsecure || clientConfig.CACertificate == certInsecure {
-		talosClient, err = talosclient.New(checkCtx,
+		talosClient, err = talosclient.New(ctx,
 			talosclient.WithTLSConfig(&tls.Config{
 				InsecureSkipVerify: true, //nolint:gosec // Insecure mode needed for maintenance-mode machines.
 			}),
@@ -339,21 +352,41 @@ func (c *external) isBootstrappedHealthy(ctx context.Context, cr *v1alpha1.Boots
 	} else {
 		talosConfig, configErr := buildBootstrapClientConfig(clientConfig)
 		if configErr != nil {
-			return false
+			return nil, configErr
 		}
 
-		talosClient, err = talosclient.New(checkCtx,
+		talosClient, err = talosclient.New(ctx,
 			talosclient.WithConfig(talosConfig),
 			talosclient.WithEndpoints(endpoint),
 		)
 	}
 	if err != nil {
+		return nil, err
+	}
+
+	return talosClient, nil
+}
+
+func isHealthyEtcdService(service *machine.ServiceInfo) bool {
+	if service == nil || service.GetId() != "etcd" || service.GetState() != "Running" {
 		return false
 	}
-	defer talosClient.Close() //nolint:errcheck
+	health := service.GetHealth()
+	if health == nil || health.GetUnknown() || !health.GetHealthy() || hasBootstrapRequiredMessage(health.GetLastMessage()) {
+		return false
+	}
 
-	_, err = talosClient.Version(talosclient.WithNode(checkCtx, cr.Spec.ForProvider.Node))
-	return err == nil
+	for _, event := range service.GetEvents().GetEvents() {
+		if hasBootstrapRequiredMessage(event.GetMsg()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hasBootstrapRequiredMessage(message string) bool {
+	return strings.Contains(strings.ToLower(message), "please run talosctl bootstrap")
 }
 
 // bootstrapTalosCluster bootstraps the Talos cluster on the specified control plane node

--- a/internal/controller/bootstrap/bootstrap_test.go
+++ b/internal/controller/bootstrap/bootstrap_test.go
@@ -33,6 +33,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -104,17 +107,40 @@ func TestObserveWithSuccessfulExternalCreate(t *testing.T) {
 	if !got.ResourceExists {
 		t.Fatal("e.Observe(...).ResourceExists = false, want true")
 	}
-	if !got.ResourceUpToDate {
-		t.Fatal("e.Observe(...).ResourceUpToDate = false, want true")
+	if got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = true, want false")
 	}
-	if !cr.Status.AtProvider.Bootstrapped {
-		t.Fatal("cr.Status.AtProvider.Bootstrapped = false, want true")
+	if cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = true, want false")
 	}
-	if cr.Status.AtProvider.BootstrapTime == nil || !cr.Status.AtProvider.BootstrapTime.Time.Equal(createdAt) {
-		t.Fatalf("cr.Status.AtProvider.BootstrapTime = %v, want %v", cr.Status.AtProvider.BootstrapTime, createdAt)
+	if cr.Status.AtProvider.BootstrapTime != nil {
+		t.Fatalf("cr.Status.AtProvider.BootstrapTime = %v, want nil", cr.Status.AtProvider.BootstrapTime)
 	}
-	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got != corev1.ConditionTrue {
-		t.Fatalf("Ready condition status = %s, want %s", got, corev1.ConditionTrue)
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got == corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want not true", got)
+	}
+}
+
+func TestObserveWithCachedBootstrappedStatusUnhealthy(t *testing.T) {
+	cr := testBootstrap()
+	cr.Status.AtProvider.Bootstrapped = true
+	now := metav1.Now()
+	cr.Status.AtProvider.BootstrapTime = &now
+
+	e := external{isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return false }}
+	got, err := e.Observe(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Observe(...): unexpected error: %v", err)
+	}
+
+	if !got.ResourceExists {
+		t.Fatal("e.Observe(...).ResourceExists = false, want true")
+	}
+	if got.ResourceUpToDate {
+		t.Fatal("e.Observe(...).ResourceUpToDate = true, want false")
+	}
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got == corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want not true", got)
 	}
 }
 
@@ -185,6 +211,28 @@ func TestCreateAlreadyExistsHealthyIsSuccess(t *testing.T) {
 	}
 }
 
+func TestCreateSuccessfulBootstrapMarksReadyOnlyWhenHealthy(t *testing.T) {
+	cr := testBootstrap()
+	e := external{
+		bootstrapFn:             func(context.Context, *v1alpha1.Bootstrap) error { return nil },
+		isBootstrappedHealthyFn: func(context.Context, *v1alpha1.Bootstrap) bool { return true },
+	}
+
+	_, err := e.Create(context.Background(), cr)
+	if err != nil {
+		t.Fatalf("e.Create(...): unexpected error: %v", err)
+	}
+	if !cr.Status.AtProvider.Bootstrapped {
+		t.Fatal("cr.Status.AtProvider.Bootstrapped = false, want true")
+	}
+	if cr.Status.AtProvider.BootstrapTime == nil {
+		t.Fatal("cr.Status.AtProvider.BootstrapTime = nil, want timestamp")
+	}
+	if got := cr.Status.GetCondition(xpv1.TypeReady).Status; got != corev1.ConditionTrue {
+		t.Fatalf("Ready condition status = %s, want %s", got, corev1.ConditionTrue)
+	}
+}
+
 func TestCreateAlreadyExistsUnhealthyReturnsError(t *testing.T) {
 	cr := testBootstrap()
 	e := external{
@@ -198,8 +246,51 @@ func TestCreateAlreadyExistsUnhealthyReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("e.Create(...): expected error")
 	}
-	if !strings.Contains(err.Error(), "health could not be verified") {
+	if !strings.Contains(err.Error(), "Talos-side bootstrap completion could not be verified") {
 		t.Fatalf("e.Create(...): got error %q, want health verification context", err.Error())
+	}
+}
+
+func TestIsBootstrappedHealthy(t *testing.T) {
+	tests := map[string]struct {
+		services []talosclient.ServiceInfo
+		err      error
+		want     bool
+	}{
+		"RunningHealthyEtcd": {
+			services: []talosclient.ServiceInfo{{Service: serviceInfo("etcd", "Running", &machineapi.ServiceHealth{Healthy: true})}},
+			want:     true,
+		},
+		"WaitingForFirstNodeBootstrap": {
+			services: []talosclient.ServiceInfo{{Service: serviceInfo("etcd", "Preparing", &machineapi.ServiceHealth{Unknown: true, LastMessage: "waiting: please run talosctl bootstrap"})}},
+			want:     false,
+		},
+		"RunningWithBootstrapRequiredEvent": {
+			services: []talosclient.ServiceInfo{{Service: serviceInfo("etcd", "Running", &machineapi.ServiceHealth{Healthy: true}, "please run talosctl bootstrap")}},
+			want:     false,
+		},
+		"NilHealth": {
+			services: []talosclient.ServiceInfo{{Service: serviceInfo("etcd", "Running", nil)}},
+			want:     false,
+		},
+		"ServiceInfoError": {
+			err:  errors.New("unavailable"),
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cr := testBootstrap()
+			e := external{newBootstrapHealthClientFn: func(context.Context, *v1alpha1.Bootstrap) (bootstrapHealthClient, error) {
+				return &fakeBootstrapHealthClient{services: tc.services, err: tc.err}, nil
+			}}
+
+			got := e.isBootstrappedHealthy(context.Background(), cr)
+			if got != tc.want {
+				t.Fatalf("e.isBootstrappedHealthy(...): got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -365,6 +456,33 @@ func testBootstrap() *v1alpha1.Bootstrap {
 			},
 		}},
 	}
+}
+
+type fakeBootstrapHealthClient struct {
+	services []talosclient.ServiceInfo
+	err      error
+}
+
+func (f *fakeBootstrapHealthClient) ServiceInfo(context.Context, string, ...grpc.CallOption) ([]talosclient.ServiceInfo, error) {
+	return f.services, f.err
+}
+
+func (f *fakeBootstrapHealthClient) Close() error { return nil }
+
+func serviceInfo(id, state string, health *machineapi.ServiceHealth, eventMessages ...string) *machineapi.ServiceInfo {
+	service := &machineapi.ServiceInfo{
+		Id:     id,
+		State:  state,
+		Health: health,
+	}
+	if len(eventMessages) > 0 {
+		service.Events = &machineapi.ServiceEvents{}
+		for _, message := range eventMessages {
+			service.Events.Events = append(service.Events.Events, &machineapi.ServiceEvent{Msg: message})
+		}
+	}
+
+	return service
 }
 
 func generateTestCertificates(t *testing.T) (string, string, string) {


### PR DESCRIPTION
### Description of your changes

Fixes #33

This changes `Bootstrap` readiness to rely on Talos-side `etcd` service state instead of local status, external-create annotations, or generic Talos API reachability. External-create annotations and cached `status.atProvider.bootstrapped` now only count as external existence to avoid repeating the non-idempotent bootstrap operation, while `Ready=True` and `ResourceUpToDate=true` require `etcd` to be running, healthy, known, and free of first-node bootstrap-required messages.

`AlreadyExists` bootstrap responses are now treated as success only when the same durable health probe verifies bootstrap completion.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `go test ./internal/controller/bootstrap`
- `go test ./...`

[contribution process]: https://git.io/fj2m9