### PR TITLE
docs: update README provider tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ kind: Provider
 metadata:
   name: provider-talos
 spec:
-  package: ghcr.io/crossplane-contrib/provider-talos:v0.1.4
+  package: ghcr.io/crossplane-contrib/provider-talos:v0.2.0
 EOF
 ```
 


### PR DESCRIPTION
## Description
Updates the README installation example to use the latest released provider tag, v0.2.0.

## Testing
Not run; README-only change.